### PR TITLE
Use nothrow

### DIFF
--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -1,9 +1,8 @@
 #ifndef SIMDJSON_PARSEDJSON_H
 #define SIMDJSON_PARSEDJSON_H
 
-#include <math.h>
-#include <inttypes.h>
-#include <string.h>
+#include <cmath>
+#include <cstring>
 #include <iomanip>
 #include <iostream>
 
@@ -227,11 +226,8 @@ private:
   bool isvalid;
 
 private :
-
- // we don't want the default constructor to be called
- ParsedJson(const ParsedJson & p); // we don't want the default constructor to be called
- // we don't want the assignment to be called
- ParsedJson & operator=(const ParsedJson&o);
+ ParsedJson(const ParsedJson & p) = delete;
+ ParsedJson & operator=(const ParsedJson&o) = delete;
 };
 
 

--- a/src/parsedjson.cpp
+++ b/src/parsedjson.cpp
@@ -48,16 +48,16 @@ bool ParsedJson::allocateCapacity(size_t len, size_t maxdepth) {
     bytecapacity = 0; // will only set it to len after allocations are a success
     n_structural_indexes = 0;
     uint32_t max_structures = ROUNDUP_N(len, 64) + 2 + 7;
-    structural_indexes = new uint32_t[max_structures];
+    structural_indexes = new (std::nothrow) uint32_t[max_structures];
     size_t localtapecapacity = ROUNDUP_N(len, 64);
     size_t localstringcapacity = ROUNDUP_N(len + 32, 64);
-    string_buf = new uint8_t[localstringcapacity];
-    tape = new uint64_t[localtapecapacity];
-    containing_scope_offset = new uint32_t[maxdepth];
+    string_buf = new (std::nothrow) uint8_t[localstringcapacity];
+    tape = new (std::nothrow) uint64_t[localtapecapacity];
+    containing_scope_offset = new (std::nothrow) uint32_t[maxdepth];
 #ifdef SIMDJSON_USE_COMPUTED_GOTO
-    ret_address = new void *[maxdepth];
+    ret_address = new (std::nothrow) void *[maxdepth];
 #else
-    ret_address = new char[maxdepth];
+    ret_address = new (std::nothrow) char[maxdepth];
 #endif
     if ((string_buf == NULL) || (tape == NULL) ||
         (containing_scope_offset == NULL) || (ret_address == NULL) || (structural_indexes == NULL)) {


### PR DESCRIPTION
None of allocation checks in `ParsedJson::allocateCapacity` would be executed, because `new` by default throws.

BTW I'm thinking about purpose of this method, and for me it looks rather like a constructor. I checked all use cases in your code and the pattern is the same: default-construct ParsedJson, then execute on that instance allocateCapacity. If all allocations were done in constructor you might use `std::unique_ptr` for memory management and also get rid of explicit `dealloce` method from API.