### PR TITLE
Add link to C# version

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,10 @@ make allparsingcompetition
 ./allparsingcompetition myfile.json
 ```
 
-## Python bindings
+## Other programming languages
 
 - [pysimdjson](https://github.com/TkTech/pysimdjson): Python bindings for the simdjson project.
+- [SimdJsonSharp](https://github.com/EgorBo/SimdJsonSharp): C# version for .NET Core
 
 
 

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -27,7 +27,7 @@
 
 
 #define really_inline inline
-#define never_inline inline
+#define never_inline __declspec(noinline)
 
 #define UNUSED
 #define WARN_UNUSED


### PR DESCRIPTION
Closes https://github.com/lemire/simdjson/issues/53 - adds link to C# impl https://github.com/EgorBo/SimdJsonSharp
Also, fixes `never_inline` macro for MSVC