### PR TITLE
(do not merge) Store strings' lengths in the tape

### DIFF
--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -128,7 +128,7 @@ public:
     // return value is valid UTF-8
     const char * get_string() const;
 
-    int32_t get_string_length() const;
+    uint32_t get_string_length() const;
 
     // get the double value at this node; valid only if
     // we're at "d"

--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -12,6 +12,7 @@
 #include "simdjson/portability.h"
 
 #define JSONVALUEMASK 0xFFFFFFFFFFFFFF
+#define JSONSTRINGLENGTHMASK 0xFFFFFFFF
 
 #define DEFAULTMAXDEPTH 1024// a JSON document with a depth exceeding 1024 is probably de facto invalid
 
@@ -126,6 +127,8 @@ public:
     // note that tabs, and line endings are escaped in the returned value (see print_with_escapes)
     // return value is valid UTF-8
     const char * get_string() const;
+
+    int32_t get_string_length() const;
 
     // get the double value at this node; valid only if
     // we're at "d"

--- a/include/simdjson/stringparsing.h
+++ b/include/simdjson/stringparsing.h
@@ -81,7 +81,6 @@ really_inline  bool parse_string(const uint8_t *buf, UNUSED size_t len,
 #else
   const uint8_t *src = &buf[offset + 1]; // we know that buf at offset is a "
   uint8_t *dst = pj.current_string_buf_loc;
-  uint8_t *dst_start = dst;
   uint8_t *const start_of_string = dst;
   while (1) {
     __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(src));
@@ -109,7 +108,7 @@ really_inline  bool parse_string(const uint8_t *buf, UNUSED size_t len,
       // we encountered quotes first. Move dst to point to quotes and exit
       dst[quote_dist] = 0; // null terminate and get out
 
-      int32_t str_length = (dst - start_of_string) + quote_dist;
+      uint32_t str_length = (dst - start_of_string) + quote_dist;
       //final value is [['"']string_length][string_buffer_offset]
       pj.write_tape(static_cast<uint64_t>(str_length) << 32 | (pj.current_string_buf_loc - pj.string_buf), '"');
       pj.current_string_buf_loc = dst + quote_dist + 1; // the +1 is due to the 0 value

--- a/src/parsedjsoniterator.cpp
+++ b/src/parsedjsoniterator.cpp
@@ -121,9 +121,14 @@ double ParsedJson::iterator::get_double()  const {
 }
 
 const char * ParsedJson::iterator::get_string() const {
-    return  reinterpret_cast<const char *>(pj.string_buf + (current_val & JSONVALUEMASK)) ;
+    return  reinterpret_cast<const char *>(pj.string_buf + (current_val & JSONSTRINGLENGTHMASK)) ;
 }
 
+int32_t ParsedJson::iterator::get_string_length() const {
+    // extract string length from current_val:
+    // [['"']string_length][string_buffer_offset]
+    return static_cast<int64_t>((current_val >> 32) - (static_cast<int64_t>('"') << 24));
+}
 
 bool ParsedJson::iterator::is_object_or_array() const {
     return is_object_or_array(get_type());

--- a/src/parsedjsoniterator.cpp
+++ b/src/parsedjsoniterator.cpp
@@ -124,10 +124,10 @@ const char * ParsedJson::iterator::get_string() const {
     return  reinterpret_cast<const char *>(pj.string_buf + (current_val & JSONSTRINGLENGTHMASK)) ;
 }
 
-int32_t ParsedJson::iterator::get_string_length() const {
+uint32_t ParsedJson::iterator::get_string_length() const {
     // extract string length from current_val:
     // [['"']string_length][string_buffer_offset]
-    return static_cast<int64_t>((current_val >> 32) - (static_cast<int64_t>('"') << 24));
+    return static_cast<uint32_t>((current_val >> 32) - (static_cast<uint64_t>('"') << 24));
 }
 
 bool ParsedJson::iterator::is_object_or_array() const {


### PR DESCRIPTION
See https://github.com/lemire/simdjson/issues/87
This PR changes string tape item layout from:
```
[['"']string_buffer_offset]
```
to
```
[['"']string_length][string_buffer_offset]
```
where `string_length` is `uint32_t`, string_buffer_offset is `uint32_t` (was `uint64_t`).

I wrote a simple test:
```
while (iterator.move_forward())
    if (iterator.is_string())
         iterator.get_string_length() == strlen(iterator.get_string());
```
not sure where to put it in the repo.

