### PR TITLE
CMake: SOVERSION should be 0 instead of 0.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 project(simdjson)
 set(SIMDJSON_LIB_NAME simdjson)
 set(SIMDJSON_LIB_VERSION "0.0.1" CACHE STRING "simdjson library version")
-set(SIMDJSON_LIB_SOVERSION "0.0.1" CACHE STRING "simdjson library soversion")
+set(SIMDJSON_LIB_SOVERSION "0" CACHE STRING "simdjson library soversion")
 
 if(NOT MSVC)
 option(SIMDJSON_BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library


### PR DESCRIPTION
I think I've made a mistake in the previous PR https://github.com/lemire/simdjson/pull/76

Here is a good example about VERSION/SOVERSION: https://github.com/intel/mkl-dnn/blob/master/src/CMakeLists.txt#L95-L96