### PR TITLE
Fix crash in singleheader test

### DIFF
--- a/tests/singleheadertest.cpp
+++ b/tests/singleheadertest.cpp
@@ -14,6 +14,6 @@ int main() {
     std::cerr << simdjson::errorMsg(res) << std::endl;
     return EXIT_FAILURE;
   }
-  free((void*)p.data());
+  aligned_free((void*)p.data());
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Use `aligned_free` instead of `free` to free memory allocated by aligned function.