### PR TITLE
Fix build warning

### DIFF
--- a/tests/singleheadertest.cpp
+++ b/tests/singleheadertest.cpp
@@ -8,7 +8,9 @@ int main() {
   if( ! pj.isValid() ) {
     return EXIT_FAILURE;
   }
-  pj.allocateCapacity(p.size());
+  if( ! pj.allocateCapacity(p.size()) ) {
+    return EXIT_FAILURE;
+  }
   const int res = json_parse(p, pj);
   if (res) {
     std::cerr << simdjson::errorMsg(res) << std::endl;


### PR DESCRIPTION
Fix following build warning:  

```
......
Scanning dependencies of target singleheader
[ 66%] Building CXX object tests/CMakeFiles/singleheader.dir/singleheadertest.cpp.o
/home/xiaonan/simdjson/tests/singleheadertest.cpp: In function ‘int main()’:
/home/xiaonan/simdjson/tests/singleheadertest.cpp:11:22: warning: ignoring return value of ‘bool ParsedJson::allocateCapacity(size_t, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
   pj.allocateCapacity(p.size());
   ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
......
```