### PR TITLE
Allows additional C(XX)FLAGS to be passed through command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ CXXFLAGS := $(CXXFLAGS) -std=c++17  -march=native -Wall -Wextra -Wshadow -Iinclu
 CFLAGS := $(CFLAGS) -march=native  -Idependencies/ujson4c/3rdparty -Idependencies/ujson4c/src -O3
 
 ifeq ($(SANITIZE),1)
-	CXXFLAGS += -g3 -O0  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined
-	CFLAGS += -g3 -O0  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined
+	CXXFLAGS += -g3 -Og  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined
+	CFLAGS += -g3 -Og  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined
 endif
 ifeq ($(DEBUG),1)
-	CXXFLAGS += -g3 -O0
-	CFLAGS += -g3 -O0
+	CXXFLAGS += -g3 -Og
+	CFLAGS += -g3 -Og
 endif
 
 MAINEXECUTABLES=parse minify json2json jsonstats statisticalmodel

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
 .PHONY: clean cleandist
 COREDEPSINCLUDE = -Idependencies/rapidjson/include -Idependencies/sajson/include -Idependencies/cJSON  -Idependencies/jsmn
 EXTRADEPSINCLUDE =  -Idependencies/jsoncppdist -Idependencies/json11 -Idependencies/fastjson/src -Idependencies/fastjson/include -Idependencies/gason/src -Idependencies/ujson4c/3rdparty -Idependencies/ujson4c/src
-CXXFLAGS =  -std=c++17  -march=native -Wall -Wextra -Wshadow -Iinclude  -Ibenchmark/linux
-CFLAGS = -march=native  -Idependencies/ujson4c/3rdparty -Idependencies/ujson4c/src
+CXXFLAGS := $(CXXFLAGS) -std=c++17  -march=native -Wall -Wextra -Wshadow -Iinclude  -Ibenchmark/linux
+CFLAGS := $(CFLAGS) -march=native  -Idependencies/ujson4c/3rdparty -Idependencies/ujson4c/src
 ifeq ($(SANITIZE),1)
 	CXXFLAGS += -g3 -O0  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined
 	CFLAGS += -g3 -O0  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined

--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,16 @@
 .PHONY: clean cleandist
 COREDEPSINCLUDE = -Idependencies/rapidjson/include -Idependencies/sajson/include -Idependencies/cJSON  -Idependencies/jsmn
 EXTRADEPSINCLUDE =  -Idependencies/jsoncppdist -Idependencies/json11 -Idependencies/fastjson/src -Idependencies/fastjson/include -Idependencies/gason/src -Idependencies/ujson4c/3rdparty -Idependencies/ujson4c/src
-CXXFLAGS := $(CXXFLAGS) -std=c++17  -march=native -Wall -Wextra -Wshadow -Iinclude  -Ibenchmark/linux
-CFLAGS := $(CFLAGS) -march=native  -Idependencies/ujson4c/3rdparty -Idependencies/ujson4c/src
+CXXFLAGS := $(CXXFLAGS) -std=c++17  -march=native -Wall -Wextra -Wshadow -Iinclude  -Ibenchmark/linux -O3
+CFLAGS := $(CFLAGS) -march=native  -Idependencies/ujson4c/3rdparty -Idependencies/ujson4c/src -O3
+
 ifeq ($(SANITIZE),1)
 	CXXFLAGS += -g3 -O0  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined
 	CFLAGS += -g3 -O0  -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined
-else
-ifeq ($(DEBUG),1)
-        CXXFLAGS += -g3 -O0
-        CFLAGS += -g3 -O0
-else
-	CXXFLAGS += -O3
-	CFLAGS += -O3
 endif
+ifeq ($(DEBUG),1)
+	CXXFLAGS += -g3 -O0
+	CFLAGS += -g3 -O0
 endif
 
 MAINEXECUTABLES=parse minify json2json jsonstats statisticalmodel


### PR DESCRIPTION
Aswell as some cleanup of the branching logic just below.

This way we can make `make CXXFLAGS="--coverage" allparserscheckfile` and `CXXFLAGS="--coverage" make allparserscheckfile` work interchangeably, without having to specify the default flags (`-std=C++17 -Iinclude ...` ) in C(XX)FLAGS which are already defined in the Makefile.