### PR TITLE
Add predicates to ParsedJson::iterator

### DIFF
--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -154,6 +154,12 @@ public:
 
     bool is_double() const;
 
+    bool is_true() const;
+
+    bool is_false() const;
+
+    bool is_null() const;
+
     static bool is_object_or_array(uint8_t type);
 
     // when at {, go one level deep, looking for a given key

--- a/src/parsedjsoniterator.cpp
+++ b/src/parsedjsoniterator.cpp
@@ -161,6 +161,18 @@ bool ParsedJson::iterator::is_double() const {
     return get_type() == 'd';
 }
 
+bool ParsedJson::iterator::is_true() const {
+    return get_type() == 't';
+}
+
+bool ParsedJson::iterator::is_false() const {
+    return get_type() == 'f';
+}
+
+bool ParsedJson::iterator::is_null() const {
+    return get_type() == 'n';
+}
+
 bool ParsedJson::iterator::is_object_or_array(uint8_t type) {
     return (type == '[' || (type == '{'));
 }


### PR DESCRIPTION
I found that some predicates is missing on `ParsedJson::iterator`. So this PR adds such a functions.