### PR TITLE
A slightly better "flatten"?

### DIFF
--- a/src/stage1_find_marks.cpp
+++ b/src/stage1_find_marks.cpp
@@ -435,24 +435,52 @@ really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base,
                                 uint32_t idx, uint64_t bits) {
   uint32_t cnt = hamming(bits);
   uint32_t next_base = base + cnt;
-  while (bits != 0u) {
-    base_ptr[base + 0] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+  idx -= 64;
+  base_ptr += base;
+  if (bits != 0) {
+    base_ptr[0] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[base + 1] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+    base_ptr[1] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[base + 2] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+    base_ptr[2] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[base + 3] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+    base_ptr[3] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[base + 4] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+    base_ptr[4] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[base + 5] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+    base_ptr[5] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[base + 6] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+    base_ptr[6] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[base + 7] = static_cast<uint32_t>(idx) - 64 + trailingzeroes(bits);
+    base_ptr[7] = idx + trailingzeroes(bits);
     bits = bits & (bits - 1);
-    base += 8;
+    base_ptr += 8;
+  }
+  if (cnt > 8) {
+    base_ptr[0] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr[1] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr[2] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr[3] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr[4] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr[5] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr[6] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr[7] = idx + trailingzeroes(bits);
+    bits = bits & (bits - 1);
+    base_ptr += 8;
+  }
+  if (cnt > 16) { // unluckly
+ do {
+      base_ptr[0] = idx + trailingzeroes(bits);
+      bits = bits & (bits - 1);
+      base_ptr++;
+    } while(bits != 0);
   }
   base = next_base;
 }


### PR DESCRIPTION
In some instances, this new "flatten" code improves results during stage 1 in a significant manner... (~10%).

This is maybe not the best design. Some further investigation is warranted, but this PR is evidence that there are more gains possible.

In number below, look at the number of cycles.

On skylake...

```
$ for i in jsonexamples/*.json ; do echo $i ; echo "-----current master:"; for j in {1..5} ; do ./parsemaster $i | grep "stage 1" ; done ; echo "------new code:"; for j in {1..5} ; do ./parse $i | grep "stage 1" ; done ; echo ; done
jsonexamples/apache_builds.json
-----current master:
stage 1 instructions:     358290 cycles:     104137 (49.22 %) ins/cycles: 3.44 mis. branches:         19 (cycles/mis.branch 5371.52) cache accesses:       3674 (failure          0)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:     358290 cycles:     104273 (48.93 %) ins/cycles: 3.44 mis. branches:         22 (cycles/mis.branch 4601.87) cache accesses:       2997 (failure          0)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:     358290 cycles:     108123 (50.57 %) ins/cycles: 3.31 mis. branches:         22 (cycles/mis.branch 4815.78) cache accesses:       3577 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     358290 cycles:     104585 (49.19 %) ins/cycles: 3.43 mis. branches:         21 (cycles/mis.branch 4804.12) cache accesses:       3914 (failure          0)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:     358290 cycles:     104111 (48.76 %) ins/cycles: 3.44 mis. branches:         22 (cycles/mis.branch 4607.71) cache accesses:       3666 (failure          0)
 stage 1 runs at 0.82 cycles per input byte.
------new code:
stage 1 instructions:     339365 cycles:     102649 (49.22 %) ins/cycles: 3.31 mis. branches:        257 (cycles/mis.branch 399.26) cache accesses:       4042 (failure          0)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     339365 cycles:     107295 (49.64 %) ins/cycles: 3.16 mis. branches:        251 (cycles/mis.branch 426.09) cache accesses:       4115 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:     339365 cycles:     108241 (49.83 %) ins/cycles: 3.14 mis. branches:        252 (cycles/mis.branch 428.81) cache accesses:       3443 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     339365 cycles:     102846 (48.73 %) ins/cycles: 3.30 mis. branches:        257 (cycles/mis.branch 399.09) cache accesses:       3924 (failure          0)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     339365 cycles:     102877 (48.86 %) ins/cycles: 3.30 mis. branches:        256 (cycles/mis.branch 401.07) cache accesses:       3108 (failure          0)
 stage 1 runs at 0.81 cycles per input byte.

jsonexamples/canada.json
-----current master:
stage 1 instructions:    6986509 cycles:    2240478 (26.21 %) ins/cycles: 3.12 mis. branches:       5461 (cycles/mis.branch 410.20) cache accesses:     116851 (failure       3025)
 stage 1 runs at 1.00 cycles per input byte.
stage 1 instructions:    6986509 cycles:    2257927 (26.38 %) ins/cycles: 3.09 mis. branches:       5463 (cycles/mis.branch 413.31) cache accesses:     116852 (failure       2140)
 stage 1 runs at 1.00 cycles per input byte.
stage 1 instructions:    6986509 cycles:    2218676 (26.30 %) ins/cycles: 3.15 mis. branches:       5449 (cycles/mis.branch 407.13) cache accesses:     108667 (failure       3313)
 stage 1 runs at 0.99 cycles per input byte.
stage 1 instructions:    6986509 cycles:    2237149 (26.19 %) ins/cycles: 3.12 mis. branches:       5453 (cycles/mis.branch 410.25) cache accesses:     108800 (failure       2304)
 stage 1 runs at 0.99 cycles per input byte.
stage 1 instructions:    6986509 cycles:    2236302 (26.19 %) ins/cycles: 3.12 mis. branches:       5458 (cycles/mis.branch 409.66) cache accesses:     108926 (failure       2876)
 stage 1 runs at 0.99 cycles per input byte.
------new code:
stage 1 instructions:    6543195 cycles:    2073745 (24.80 %) ins/cycles: 3.16 mis. branches:       5905 (cycles/mis.branch 351.14) cache accesses:     108904 (failure       3318)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    6543195 cycles:    2052723 (24.89 %) ins/cycles: 3.19 mis. branches:       5895 (cycles/mis.branch 348.20) cache accesses:     116778 (failure       2757)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    6543195 cycles:    2077014 (24.84 %) ins/cycles: 3.15 mis. branches:       5912 (cycles/mis.branch 351.29) cache accesses:     116848 (failure       2232)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    6543195 cycles:    2176421 (25.72 %) ins/cycles: 3.01 mis. branches:       5869 (cycles/mis.branch 370.83) cache accesses:     117030 (failure       2272)
 stage 1 runs at 0.97 cycles per input byte.
stage 1 instructions:    6543195 cycles:    2077857 (25.12 %) ins/cycles: 3.15 mis. branches:       5919 (cycles/mis.branch 351.03) cache accesses:     108816 (failure       3213)
 stage 1 runs at 0.92 cycles per input byte.

jsonexamples/citm_catalog.json
-----current master:
stage 1 instructions:    4636000 cycles:    1350908 (50.39 %) ins/cycles: 3.43 mis. branches:        253 (cycles/mis.branch 5333.23) cache accesses:      71026 (failure        383)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    4636000 cycles:    1350153 (50.39 %) ins/cycles: 3.43 mis. branches:        248 (cycles/mis.branch 5431.03) cache accesses:      76551 (failure        358)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    4636000 cycles:    1350263 (50.40 %) ins/cycles: 3.43 mis. branches:        245 (cycles/mis.branch 5502.30) cache accesses:      76416 (failure        282)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    4636000 cycles:    1350776 (50.40 %) ins/cycles: 3.43 mis. branches:        245 (cycles/mis.branch 5493.20) cache accesses:      76353 (failure        298)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    4636000 cycles:    1351124 (50.42 %) ins/cycles: 3.43 mis. branches:        246 (cycles/mis.branch 5472.35) cache accesses:      76384 (failure        559)
 stage 1 runs at 0.78 cycles per input byte.
------new code:
stage 1 instructions:    4417697 cycles:    1304673 (49.56 %) ins/cycles: 3.39 mis. branches:        338 (cycles/mis.branch 3858.84) cache accesses:      76295 (failure        313)
 stage 1 runs at 0.76 cycles per input byte.
stage 1 instructions:    4417697 cycles:    1304150 (49.55 %) ins/cycles: 3.39 mis. branches:        331 (cycles/mis.branch 3940.03) cache accesses:      76448 (failure        349)
 stage 1 runs at 0.76 cycles per input byte.
stage 1 instructions:    4417697 cycles:    1304649 (49.64 %) ins/cycles: 3.39 mis. branches:        328 (cycles/mis.branch 3973.96) cache accesses:      76374 (failure        385)
 stage 1 runs at 0.76 cycles per input byte.
stage 1 instructions:    4417697 cycles:    1390767 (50.92 %) ins/cycles: 3.18 mis. branches:        338 (cycles/mis.branch 4111.05) cache accesses:      76519 (failure        372)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:    4417697 cycles:    1305403 (49.60 %) ins/cycles: 3.38 mis. branches:        337 (cycles/mis.branch 3864.43) cache accesses:      71104 (failure        350)
 stage 1 runs at 0.76 cycles per input byte.

jsonexamples/github_events.json
-----current master:
stage 1 instructions:     173152 cycles:      50883 (49.01 %) ins/cycles: 3.40 mis. branches:          3 (cycles/mis.branch 14225.31) cache accesses:        535 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     173152 cycles:      50907 (48.97 %) ins/cycles: 3.40 mis. branches:          5 (cycles/mis.branch 10088.74) cache accesses:        269 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     173152 cycles:      50790 (49.30 %) ins/cycles: 3.41 mis. branches:          6 (cycles/mis.branch 7810.27) cache accesses:        722 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     173152 cycles:      51038 (49.15 %) ins/cycles: 3.39 mis. branches:          6 (cycles/mis.branch 8495.05) cache accesses:       1177 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     173152 cycles:      50322 (48.66 %) ins/cycles: 3.44 mis. branches:          5 (cycles/mis.branch 9842.12) cache accesses:        865 (failure          0)
 stage 1 runs at 0.77 cycles per input byte.
------new code:
stage 1 instructions:     165019 cycles:      53952 (50.55 %) ins/cycles: 3.06 mis. branches:         13 (cycles/mis.branch 3989.65) cache accesses:        336 (failure          0)
 stage 1 runs at 0.83 cycles per input byte.
stage 1 instructions:     165019 cycles:      49427 (48.65 %) ins/cycles: 3.34 mis. branches:         14 (cycles/mis.branch 3491.11) cache accesses:        263 (failure          0)
 stage 1 runs at 0.76 cycles per input byte.
stage 1 instructions:     165019 cycles:      49021 (48.45 %) ins/cycles: 3.37 mis. branches:         16 (cycles/mis.branch 2987.64) cache accesses:        720 (failure          0)
 stage 1 runs at 0.75 cycles per input byte.
stage 1 instructions:     165019 cycles:      49107 (48.38 %) ins/cycles: 3.36 mis. branches:         13 (cycles/mis.branch 3528.83) cache accesses:        492 (failure          0)
 stage 1 runs at 0.75 cycles per input byte.
stage 1 instructions:     165019 cycles:      49109 (48.64 %) ins/cycles: 3.36 mis. branches:         22 (cycles/mis.branch 2138.16) cache accesses:        281 (failure          0)
 stage 1 runs at 0.75 cycles per input byte.

jsonexamples/gsoc-2018.json
-----current master:
stage 1 instructions:    7371208 cycles:    2245000 (54.04 %) ins/cycles: 3.28 mis. branches:       5640 (cycles/mis.branch 398.02) cache accesses:     126296 (failure       6477)
 stage 1 runs at 0.67 cycles per input byte.
stage 1 instructions:    7371208 cycles:    2246081 (54.11 %) ins/cycles: 3.28 mis. branches:       5665 (cycles/mis.branch 396.42) cache accesses:     126434 (failure       5434)
 stage 1 runs at 0.67 cycles per input byte.
stage 1 instructions:    7371208 cycles:    2238592 (54.27 %) ins/cycles: 3.29 mis. branches:       5647 (cycles/mis.branch 396.37) cache accesses:     118921 (failure       6170)
 stage 1 runs at 0.67 cycles per input byte.
stage 1 instructions:    7371208 cycles:    2247983 (54.09 %) ins/cycles: 3.28 mis. branches:       5651 (cycles/mis.branch 397.75) cache accesses:     119048 (failure       7507)
 stage 1 runs at 0.68 cycles per input byte.
stage 1 instructions:    7371209 cycles:    2247357 (54.06 %) ins/cycles: 3.28 mis. branches:       5652 (cycles/mis.branch 397.57) cache accesses:     119188 (failure       6666)
 stage 1 runs at 0.68 cycles per input byte.
------new code:
stage 1 instructions:    7165709 cycles:    2222142 (54.48 %) ins/cycles: 3.22 mis. branches:       6715 (cycles/mis.branch 330.89) cache accesses:     119065 (failure       5901)
 stage 1 runs at 0.67 cycles per input byte.
stage 1 instructions:    7165709 cycles:    2223149 (54.56 %) ins/cycles: 3.22 mis. branches:       6672 (cycles/mis.branch 333.18) cache accesses:     119218 (failure       6715)
 stage 1 runs at 0.67 cycles per input byte.
stage 1 instructions:    7165709 cycles:    2241994 (54.95 %) ins/cycles: 3.20 mis. branches:       6710 (cycles/mis.branch 334.12) cache accesses:     126453 (failure       5339)
 stage 1 runs at 0.67 cycles per input byte.
stage 1 instructions:    7165709 cycles:    2223832 (54.49 %) ins/cycles: 3.22 mis. branches:       6708 (cycles/mis.branch 331.48) cache accesses:     126384 (failure       5662)
 stage 1 runs at 0.67 cycles per input byte.
stage 1 instructions:    7165709 cycles:    2224995 (54.55 %) ins/cycles: 3.22 mis. branches:       6694 (cycles/mis.branch 332.35) cache accesses:     126255 (failure       5405)
 stage 1 runs at 0.67 cycles per input byte.

jsonexamples/instruments.json
-----current master:
stage 1 instructions:     633731 cycles:     185943 (45.79 %) ins/cycles: 3.41 mis. branches:         69 (cycles/mis.branch 2689.49) cache accesses:      10407 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:     633731 cycles:     184540 (45.65 %) ins/cycles: 3.43 mis. branches:         69 (cycles/mis.branch 2670.74) cache accesses:      10468 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:     633731 cycles:     184306 (45.45 %) ins/cycles: 3.44 mis. branches:         67 (cycles/mis.branch 2741.71) cache accesses:      10110 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:     633731 cycles:     187195 (45.63 %) ins/cycles: 3.39 mis. branches:         70 (cycles/mis.branch 2667.21) cache accesses:      10320 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     633731 cycles:     184591 (45.61 %) ins/cycles: 3.43 mis. branches:         69 (cycles/mis.branch 2659.05) cache accesses:      10943 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.
------new code:
stage 1 instructions:     598719 cycles:     183125 (45.25 %) ins/cycles: 3.27 mis. branches:        482 (cycles/mis.branch 379.90) cache accesses:      10887 (failure          0)
 stage 1 runs at 0.83 cycles per input byte.
stage 1 instructions:     598719 cycles:     183746 (45.34 %) ins/cycles: 3.26 mis. branches:        468 (cycles/mis.branch 391.97) cache accesses:      10333 (failure          0)
 stage 1 runs at 0.83 cycles per input byte.
stage 1 instructions:     598719 cycles:     181320 (45.14 %) ins/cycles: 3.30 mis. branches:        474 (cycles/mis.branch 381.96) cache accesses:       9774 (failure          0)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:     598719 cycles:     183325 (45.21 %) ins/cycles: 3.27 mis. branches:        469 (cycles/mis.branch 390.22) cache accesses:      10257 (failure          0)
 stage 1 runs at 0.83 cycles per input byte.
stage 1 instructions:     598719 cycles:     184632 (45.22 %) ins/cycles: 3.24 mis. branches:        476 (cycles/mis.branch 387.41) cache accesses:      10438 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.

jsonexamples/marine_ik.json
-----current master:
stage 1 instructions:   10276363 cycles:    3481194 (27.34 %) ins/cycles: 2.95 mis. branches:       5617 (cycles/mis.branch 619.76) cache accesses:     168852 (failure      31018)
 stage 1 runs at 1.17 cycles per input byte.
stage 1 instructions:   10276363 cycles:    3279264 (26.18 %) ins/cycles: 3.13 mis. branches:       5599 (cycles/mis.branch 585.69) cache accesses:     169287 (failure      34326)
 stage 1 runs at 1.10 cycles per input byte.
stage 1 instructions:   10276363 cycles:    3249157 (26.14 %) ins/cycles: 3.16 mis. branches:       5605 (cycles/mis.branch 579.67) cache accesses:     178307 (failure      33179)
 stage 1 runs at 1.09 cycles per input byte.
stage 1 instructions:   10276363 cycles:    3277887 (26.15 %) ins/cycles: 3.14 mis. branches:       5597 (cycles/mis.branch 585.62) cache accesses:     177487 (failure      35121)
 stage 1 runs at 1.10 cycles per input byte.
stage 1 instructions:   10276363 cycles:    3247994 (26.15 %) ins/cycles: 3.16 mis. branches:       5593 (cycles/mis.branch 580.68) cache accesses:     168517 (failure      32918)
 stage 1 runs at 1.09 cycles per input byte.
------new code:
stage 1 instructions:    9480969 cycles:    3016281 (24.80 %) ins/cycles: 3.14 mis. branches:       8422 (cycles/mis.branch 358.12) cache accesses:     168576 (failure      34475)
 stage 1 runs at 1.01 cycles per input byte.
stage 1 instructions:    9480969 cycles:    3014986 (24.78 %) ins/cycles: 3.14 mis. branches:       8325 (cycles/mis.branch 362.15) cache accesses:     168483 (failure      33425)
 stage 1 runs at 1.01 cycles per input byte.
stage 1 instructions:    9480969 cycles:    3043987 (24.82 %) ins/cycles: 3.11 mis. branches:       8376 (cycles/mis.branch 363.38) cache accesses:     169031 (failure      34169)
 stage 1 runs at 1.02 cycles per input byte.
stage 1 instructions:    9480969 cycles:    3043301 (24.81 %) ins/cycles: 3.12 mis. branches:       8368 (cycles/mis.branch 363.68) cache accesses:     168907 (failure      32712)
 stage 1 runs at 1.02 cycles per input byte.
stage 1 instructions:    9480969 cycles:    3081391 (25.04 %) ins/cycles: 3.08 mis. branches:       8363 (cycles/mis.branch 368.43) cache accesses:     177399 (failure      33327)
 stage 1 runs at 1.03 cycles per input byte.

jsonexamples/mesh.json
-----current master:
stage 1 instructions:    2377005 cycles:     701351 (24.65 %) ins/cycles: 3.39 mis. branches:        391 (cycles/mis.branch 1790.85) cache accesses:      43711 (failure          5)
 stage 1 runs at 0.97 cycles per input byte.
stage 1 instructions:    2377005 cycles:     701480 (24.65 %) ins/cycles: 3.39 mis. branches:        390 (cycles/mis.branch 1796.73) cache accesses:      43748 (failure          1)
 stage 1 runs at 0.97 cycles per input byte.
stage 1 instructions:    2377005 cycles:     707549 (24.53 %) ins/cycles: 3.36 mis. branches:        390 (cycles/mis.branch 1812.60) cache accesses:      43785 (failure          2)
 stage 1 runs at 0.98 cycles per input byte.
stage 1 instructions:    2377005 cycles:     708262 (24.55 %) ins/cycles: 3.36 mis. branches:        387 (cycles/mis.branch 1825.95) cache accesses:      43805 (failure          1)
 stage 1 runs at 0.98 cycles per input byte.
stage 1 instructions:    2377005 cycles:     707432 (24.52 %) ins/cycles: 3.36 mis. branches:        384 (cycles/mis.branch 1839.36) cache accesses:      43832 (failure          0)
 stage 1 runs at 0.98 cycles per input byte.
------new code:
stage 1 instructions:    2219085 cycles:     658281 (23.47 %) ins/cycles: 3.37 mis. branches:        978 (cycles/mis.branch 672.42) cache accesses:      46847 (failure          1)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    2219085 cycles:     675090 (23.66 %) ins/cycles: 3.29 mis. branches:        974 (cycles/mis.branch 692.51) cache accesses:      46817 (failure          1)
 stage 1 runs at 0.93 cycles per input byte.
stage 1 instructions:    2219085 cycles:     686890 (23.98 %) ins/cycles: 3.23 mis. branches:        978 (cycles/mis.branch 702.08) cache accesses:      46828 (failure          1)
 stage 1 runs at 0.95 cycles per input byte.
stage 1 instructions:    2219085 cycles:     656962 (23.45 %) ins/cycles: 3.38 mis. branches:        979 (cycles/mis.branch 670.68) cache accesses:      43748 (failure          1)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    2219085 cycles:     674316 (23.65 %) ins/cycles: 3.29 mis. branches:        975 (cycles/mis.branch 690.90) cache accesses:      43854 (failure          3)
 stage 1 runs at 0.93 cycles per input byte.

jsonexamples/mesh.pretty.json
-----current master:
stage 1 instructions:    4404605 cycles:    1300807 (30.41 %) ins/cycles: 3.39 mis. branches:         35 (cycles/mis.branch 36437.18) cache accesses:      67942 (failure        331)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:    4404605 cycles:    1286155 (30.40 %) ins/cycles: 3.42 mis. branches:         32 (cycles/mis.branch 39696.16) cache accesses:      72849 (failure        338)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:    4404605 cycles:    1287802 (30.43 %) ins/cycles: 3.42 mis. branches:         33 (cycles/mis.branch 38906.40) cache accesses:      72793 (failure        478)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:    4404605 cycles:    1285715 (30.39 %) ins/cycles: 3.43 mis. branches:         36 (cycles/mis.branch 35714.32) cache accesses:      72943 (failure        267)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:    4404605 cycles:    1287380 (30.41 %) ins/cycles: 3.42 mis. branches:         31 (cycles/mis.branch 40739.89) cache accesses:      72849 (failure        381)
 stage 1 runs at 0.82 cycles per input byte.
------new code:
stage 1 instructions:    4175818 cycles:    1235983 (29.53 %) ins/cycles: 3.38 mis. branches:         44 (cycles/mis.branch 27588.92) cache accesses:      72905 (failure        292)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    4175818 cycles:    1321404 (30.73 %) ins/cycles: 3.16 mis. branches:         47 (cycles/mis.branch 27936.67) cache accesses:      72928 (failure        305)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:    4175818 cycles:    1236109 (29.47 %) ins/cycles: 3.38 mis. branches:         44 (cycles/mis.branch 27530.27) cache accesses:      67749 (failure        281)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    4175818 cycles:    1236048 (29.54 %) ins/cycles: 3.38 mis. branches:         46 (cycles/mis.branch 26696.51) cache accesses:      67879 (failure        267)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    4175818 cycles:    1236335 (29.53 %) ins/cycles: 3.38 mis. branches:         43 (cycles/mis.branch 28226.83) cache accesses:      67859 (failure        495)
 stage 1 runs at 0.78 cycles per input byte.

jsonexamples/numbers.json
-----current master:
stage 1 instructions:     434384 cycles:     126746 (24.40 %) ins/cycles: 3.43 mis. branches:         48 (cycles/mis.branch 2607.90) cache accesses:       6019 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:     434384 cycles:     127798 (24.20 %) ins/cycles: 3.40 mis. branches:         44 (cycles/mis.branch 2844.71) cache accesses:       5415 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     434384 cycles:     134606 (25.54 %) ins/cycles: 3.23 mis. branches:         42 (cycles/mis.branch 3155.03) cache accesses:       5708 (failure          0)
 stage 1 runs at 0.90 cycles per input byte.
stage 1 instructions:     434384 cycles:     126087 (24.30 %) ins/cycles: 3.45 mis. branches:         31 (cycles/mis.branch 3988.60) cache accesses:       5747 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:     434384 cycles:     128985 (24.72 %) ins/cycles: 3.37 mis. branches:         37 (cycles/mis.branch 3472.31) cache accesses:       6438 (failure          0)
 stage 1 runs at 0.86 cycles per input byte.
------new code:
stage 1 instructions:     410108 cycles:     127614 (24.31 %) ins/cycles: 3.21 mis. branches:        418 (cycles/mis.branch 304.88) cache accesses:       6045 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     410108 cycles:     127738 (24.32 %) ins/cycles: 3.21 mis. branches:        421 (cycles/mis.branch 303.27) cache accesses:       5910 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     410108 cycles:     127861 (24.34 %) ins/cycles: 3.21 mis. branches:        417 (cycles/mis.branch 306.06) cache accesses:       5228 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     410108 cycles:     127740 (24.32 %) ins/cycles: 3.21 mis. branches:        422 (cycles/mis.branch 302.31) cache accesses:       6652 (failure          0)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:     410108 cycles:     125866 (24.33 %) ins/cycles: 3.26 mis. branches:        417 (cycles/mis.branch 301.68) cache accesses:       5755 (failure          0)
 stage 1 runs at 0.84 cycles per input byte.

jsonexamples/random.json
-----current master:
stage 1 instructions:    2073625 cycles:     645596 (47.21 %) ins/cycles: 3.21 mis. branches:        815 (cycles/mis.branch 792.09) cache accesses:      28169 (failure          1)
 stage 1 runs at 1.26 cycles per input byte.
stage 1 instructions:    2073625 cycles:     637249 (47.05 %) ins/cycles: 3.25 mis. branches:        830 (cycles/mis.branch 767.45) cache accesses:      30074 (failure          0)
 stage 1 runs at 1.25 cycles per input byte.
stage 1 instructions:    2073625 cycles:     646575 (47.15 %) ins/cycles: 3.21 mis. branches:        838 (cycles/mis.branch 771.20) cache accesses:      30191 (failure          2)
 stage 1 runs at 1.27 cycles per input byte.
stage 1 instructions:    2073625 cycles:     636173 (47.00 %) ins/cycles: 3.26 mis. branches:        803 (cycles/mis.branch 791.41) cache accesses:      28091 (failure          6)
 stage 1 runs at 1.25 cycles per input byte.
stage 1 instructions:    2073625 cycles:     645531 (47.29 %) ins/cycles: 3.21 mis. branches:        820 (cycles/mis.branch 786.71) cache accesses:      28214 (failure          1)
 stage 1 runs at 1.26 cycles per input byte.
------new code:
stage 1 instructions:    1954170 cycles:     615572 (46.12 %) ins/cycles: 3.17 mis. branches:        940 (cycles/mis.branch 654.41) cache accesses:      28251 (failure          0)
 stage 1 runs at 1.21 cycles per input byte.
stage 1 instructions:    1954170 cycles:     607275 (45.45 %) ins/cycles: 3.22 mis. branches:        930 (cycles/mis.branch 652.78) cache accesses:      28284 (failure          1)
 stage 1 runs at 1.19 cycles per input byte.
stage 1 instructions:    1954170 cycles:     607482 (45.57 %) ins/cycles: 3.22 mis. branches:        944 (cycles/mis.branch 643.39) cache accesses:      28272 (failure         11)
 stage 1 runs at 1.19 cycles per input byte.
stage 1 instructions:    1954170 cycles:     597988 (44.66 %) ins/cycles: 3.27 mis. branches:        931 (cycles/mis.branch 641.89) cache accesses:      30133 (failure          0)
 stage 1 runs at 1.17 cycles per input byte.
stage 1 instructions:    1954170 cycles:     598487 (45.52 %) ins/cycles: 3.27 mis. branches:        940 (cycles/mis.branch 636.24) cache accesses:      30217 (failure          0)
 stage 1 runs at 1.17 cycles per input byte.

jsonexamples/twitterescaped.json
-----current master:
stage 1 instructions:    1528188 cycles:     465027 (26.19 %) ins/cycles: 3.29 mis. branches:       1019 (cycles/mis.branch 456.26) cache accesses:      27433 (failure          0)
 stage 1 runs at 0.83 cycles per input byte.
stage 1 instructions:    1528188 cycles:     464546 (26.30 %) ins/cycles: 3.29 mis. branches:       1000 (cycles/mis.branch 464.18) cache accesses:      27438 (failure          2)
 stage 1 runs at 0.83 cycles per input byte.
stage 1 instructions:    1528188 cycles:     465700 (26.33 %) ins/cycles: 3.28 mis. branches:        995 (cycles/mis.branch 467.89) cache accesses:      27398 (failure          0)
 stage 1 runs at 0.83 cycles per input byte.
stage 1 instructions:    1528188 cycles:     480756 (26.91 %) ins/cycles: 3.18 mis. branches:       1011 (cycles/mis.branch 475.38) cache accesses:      27366 (failure          1)
 stage 1 runs at 0.85 cycles per input byte.
stage 1 instructions:    1528188 cycles:     465084 (26.30 %) ins/cycles: 3.29 mis. branches:       1004 (cycles/mis.branch 463.02) cache accesses:      27427 (failure          0)
 stage 1 runs at 0.83 cycles per input byte.
------new code:
stage 1 instructions:    1440895 cycles:     444696 (25.41 %) ins/cycles: 3.24 mis. branches:       1432 (cycles/mis.branch 310.41) cache accesses:      27442 (failure          0)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:    1440895 cycles:     446843 (25.39 %) ins/cycles: 3.22 mis. branches:       1406 (cycles/mis.branch 317.77) cache accesses:      27429 (failure          0)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:    1440895 cycles:     444248 (25.39 %) ins/cycles: 3.24 mis. branches:       1408 (cycles/mis.branch 315.47) cache accesses:      25793 (failure          0)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:    1440895 cycles:     444410 (25.41 %) ins/cycles: 3.24 mis. branches:       1411 (cycles/mis.branch 314.86) cache accesses:      25806 (failure          0)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:    1440895 cycles:     446580 (25.37 %) ins/cycles: 3.23 mis. branches:       1412 (cycles/mis.branch 316.14) cache accesses:      25861 (failure          0)
 stage 1 runs at 0.79 cycles per input byte.

jsonexamples/twitter.json
-----current master:
stage 1 instructions:    1901483 cycles:     575314 (52.48 %) ins/cycles: 3.31 mis. branches:        948 (cycles/mis.branch 606.48) cache accesses:      29912 (failure          1)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    1901483 cycles:     575668 (53.24 %) ins/cycles: 3.30 mis. branches:        953 (cycles/mis.branch 603.50) cache accesses:      29963 (failure          0)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    1901483 cycles:     575455 (53.30 %) ins/cycles: 3.30 mis. branches:        924 (cycles/mis.branch 622.65) cache accesses:      29978 (failure          0)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    1901483 cycles:     581192 (53.37 %) ins/cycles: 3.27 mis. branches:        938 (cycles/mis.branch 619.29) cache accesses:      29886 (failure          0)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    1901483 cycles:     575781 (53.14 %) ins/cycles: 3.30 mis. branches:        957 (cycles/mis.branch 601.30) cache accesses:      29944 (failure          0)
 stage 1 runs at 0.91 cycles per input byte.
------new code:
stage 1 instructions:    1813178 cycles:     553996 (51.91 %) ins/cycles: 3.27 mis. branches:       1242 (cycles/mis.branch 446.02) cache accesses:      29887 (failure          0)
 stage 1 runs at 0.88 cycles per input byte.
stage 1 instructions:    1813178 cycles:     595388 (53.70 %) ins/cycles: 3.05 mis. branches:       1242 (cycles/mis.branch 479.31) cache accesses:      29997 (failure          4)
 stage 1 runs at 0.94 cycles per input byte.
stage 1 instructions:    1813178 cycles:     553930 (51.90 %) ins/cycles: 3.27 mis. branches:       1232 (cycles/mis.branch 449.51) cache accesses:      29904 (failure          0)
 stage 1 runs at 0.88 cycles per input byte.
stage 1 instructions:    1813178 cycles:     554051 (51.95 %) ins/cycles: 3.27 mis. branches:       1247 (cycles/mis.branch 444.28) cache accesses:      29889 (failure          0)
 stage 1 runs at 0.88 cycles per input byte.
stage 1 instructions:    1813178 cycles:     554101 (52.07 %) ins/cycles: 3.27 mis. branches:       1236 (cycles/mis.branch 448.17) cache accesses:      29908 (failure         15)
 stage 1 runs at 0.88 cycles per input byte.

jsonexamples/update-center.json
-----current master:
stage 1 instructions:    1526735 cycles:     486388 (44.17 %) ins/cycles: 3.14 mis. branches:       2040 (cycles/mis.branch 238.37) cache accesses:      27679 (failure          0)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    1526735 cycles:     487916 (44.24 %) ins/cycles: 3.13 mis. branches:       2058 (cycles/mis.branch 237.08) cache accesses:      27605 (failure          1)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    1526735 cycles:     487378 (44.10 %) ins/cycles: 3.13 mis. branches:       2056 (cycles/mis.branch 236.95) cache accesses:      27620 (failure          0)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    1526735 cycles:     488385 (44.22 %) ins/cycles: 3.13 mis. branches:       2066 (cycles/mis.branch 236.35) cache accesses:      27604 (failure          0)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    1526735 cycles:     487143 (44.18 %) ins/cycles: 3.13 mis. branches:       2057 (cycles/mis.branch 236.76) cache accesses:      27651 (failure          0)
 stage 1 runs at 0.91 cycles per input byte.
------new code:
stage 1 instructions:    1439809 cycles:     455891 (42.16 %) ins/cycles: 3.16 mis. branches:       2422 (cycles/mis.branch 188.23) cache accesses:      27591 (failure          0)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1439809 cycles:     456108 (42.25 %) ins/cycles: 3.16 mis. branches:       2421 (cycles/mis.branch 188.39) cache accesses:      27626 (failure          0)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1439809 cycles:     456010 (42.56 %) ins/cycles: 3.16 mis. branches:       2426 (cycles/mis.branch 187.95) cache accesses:      27580 (failure          0)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1439809 cycles:     456546 (42.39 %) ins/cycles: 3.15 mis. branches:       2428 (cycles/mis.branch 188.01) cache accesses:      27615 (failure          0)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1439809 cycles:     455602 (42.51 %) ins/cycles: 3.16 mis. branches:       2416 (cycles/mis.branch 188.52) cache accesses:      27610 (failure          1)
 stage 1 runs at 0.85 cycles per input byte.
```

On Cannon Lake:
```
$ for i in jsonexamples/*.json ; do echo $i ; echo "-----current master:"; for j in {1..5} ; do ./parsemaster $i | grep "stage 1" ; done ; echo "------new code:"; for j in {1..5} ; do ./parse $i | grep "stage 1" ; done ; echo ; done
jsonexamples/apache_builds.json
-----current master:
stage 1 instructions:     373669 cycles:     100619 (42.37 %) ins/cycles: 3.71 mis. branches:         30 (cycles/mis.branch 3249.76) cache accesses:       1848 (failure          2)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:     373669 cycles:      99644 (42.01 %) ins/cycles: 3.75 mis. branches:         27 (cycles/mis.branch 3583.31) cache accesses:       1947 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     373669 cycles:      99630 (43.09 %) ins/cycles: 3.75 mis. branches:         25 (cycles/mis.branch 3881.83) cache accesses:       1602 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     373669 cycles:     100350 (43.70 %) ins/cycles: 3.72 mis. branches:         26 (cycles/mis.branch 3789.23) cache accesses:       1680 (failure          0)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:     373669 cycles:      99479 (43.23 %) ins/cycles: 3.76 mis. branches:         20 (cycles/mis.branch 4866.40) cache accesses:       1679 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
------new code:
stage 1 instructions:     354731 cycles:      95913 (41.87 %) ins/cycles: 3.70 mis. branches:        183 (cycles/mis.branch 523.28) cache accesses:       1899 (failure          0)
 stage 1 runs at 0.75 cycles per input byte.
stage 1 instructions:     354731 cycles:      95723 (41.83 %) ins/cycles: 3.71 mis. branches:        172 (cycles/mis.branch 553.52) cache accesses:       1771 (failure          0)
 stage 1 runs at 0.75 cycles per input byte.
stage 1 instructions:     354731 cycles:      95766 (43.86 %) ins/cycles: 3.70 mis. branches:        172 (cycles/mis.branch 556.64) cache accesses:       1404 (failure          0)
 stage 1 runs at 0.75 cycles per input byte.
stage 1 instructions:     354731 cycles:      95559 (41.32 %) ins/cycles: 3.71 mis. branches:        169 (cycles/mis.branch 564.75) cache accesses:       1605 (failure          0)
 stage 1 runs at 0.75 cycles per input byte.
stage 1 instructions:     354731 cycles:      96901 (42.22 %) ins/cycles: 3.66 mis. branches:        162 (cycles/mis.branch 596.60) cache accesses:       1721 (failure          0)
 stage 1 runs at 0.76 cycles per input byte.

jsonexamples/canada.json
-----current master:
stage 1 instructions:    7382444 cycles:    3118638 (19.65 %) ins/cycles: 2.37 mis. branches:       5286 (cycles/mis.branch 589.89) cache accesses:      55598 (failure      21531)
 stage 1 runs at 1.39 cycles per input byte.
stage 1 instructions:    7382503 cycles:    3115871 (19.17 %) ins/cycles: 2.37 mis. branches:       5386 (cycles/mis.branch 578.42) cache accesses:      52099 (failure      20551)
 stage 1 runs at 1.38 cycles per input byte.
stage 1 instructions:    7382476 cycles:    3145245 (19.69 %) ins/cycles: 2.35 mis. branches:       5388 (cycles/mis.branch 583.70) cache accesses:      53611 (failure      21231)
 stage 1 runs at 1.40 cycles per input byte.
stage 1 instructions:    7382492 cycles:    3039751 (19.00 %) ins/cycles: 2.43 mis. branches:       5462 (cycles/mis.branch 556.46) cache accesses:      52634 (failure      19745)
 stage 1 runs at 1.35 cycles per input byte.
stage 1 instructions:    7382490 cycles:    3055307 (19.98 %) ins/cycles: 2.42 mis. branches:       5392 (cycles/mis.branch 566.57) cache accesses:      52737 (failure      17896)
 stage 1 runs at 1.36 cycles per input byte.
------new code:
stage 1 instructions:    6939187 cycles:    2898573 (18.29 %) ins/cycles: 2.39 mis. branches:       5472 (cycles/mis.branch 529.64) cache accesses:      52093 (failure      20945)
 stage 1 runs at 1.29 cycles per input byte.
stage 1 instructions:    6939161 cycles:    2789763 (18.13 %) ins/cycles: 2.49 mis. branches:       5494 (cycles/mis.branch 507.76) cache accesses:      53561 (failure      20192)
 stage 1 runs at 1.24 cycles per input byte.
stage 1 instructions:    6939150 cycles:    3009130 (18.44 %) ins/cycles: 2.31 mis. branches:       5410 (cycles/mis.branch 556.19) cache accesses:      54176 (failure      23223)
 stage 1 runs at 1.34 cycles per input byte.
stage 1 instructions:    6939172 cycles:    3007377 (19.50 %) ins/cycles: 2.31 mis. branches:       5450 (cycles/mis.branch 551.76) cache accesses:      52872 (failure      19650)
 stage 1 runs at 1.34 cycles per input byte.
stage 1 instructions:    6939187 cycles:    2899289 (18.86 %) ins/cycles: 2.39 mis. branches:       5452 (cycles/mis.branch 531.77) cache accesses:      52094 (failure      18239)
 stage 1 runs at 1.29 cycles per input byte.

jsonexamples/citm_catalog.json
-----current master:
stage 1 instructions:    4799928 cycles:    1549629 (38.16 %) ins/cycles: 3.10 mis. branches:        265 (cycles/mis.branch 5845.45) cache accesses:      33951 (failure       3558)
 stage 1 runs at 0.90 cycles per input byte.
stage 1 instructions:    4799928 cycles:    1546010 (38.66 %) ins/cycles: 3.10 mis. branches:        261 (cycles/mis.branch 5914.35) cache accesses:      33964 (failure       3395)
 stage 1 runs at 0.90 cycles per input byte.
stage 1 instructions:    4799927 cycles:    1637039 (38.13 %) ins/cycles: 2.93 mis. branches:        271 (cycles/mis.branch 6025.17) cache accesses:      34003 (failure       5075)
 stage 1 runs at 0.95 cycles per input byte.
stage 1 instructions:    4799928 cycles:    1581443 (37.80 %) ins/cycles: 3.04 mis. branches:        255 (cycles/mis.branch 6187.18) cache accesses:      33947 (failure       3996)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    4799928 cycles:    1566228 (38.33 %) ins/cycles: 3.06 mis. branches:        258 (cycles/mis.branch 6061.26) cache accesses:      33959 (failure       3761)
 stage 1 runs at 0.91 cycles per input byte.
------new code:
stage 1 instructions:    4581797 cycles:    1500347 (37.25 %) ins/cycles: 3.05 mis. branches:        304 (cycles/mis.branch 4933.73) cache accesses:      33950 (failure       3735)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    4581795 cycles:    1577185 (38.13 %) ins/cycles: 2.91 mis. branches:        310 (cycles/mis.branch 5076.23) cache accesses:      34041 (failure       4772)
 stage 1 runs at 0.91 cycles per input byte.
stage 1 instructions:    4581798 cycles:    1545893 (36.65 %) ins/cycles: 2.96 mis. branches:        310 (cycles/mis.branch 4986.75) cache accesses:      33962 (failure       4447)
 stage 1 runs at 0.90 cycles per input byte.
stage 1 instructions:    4581797 cycles:    1526743 (36.60 %) ins/cycles: 3.00 mis. branches:        311 (cycles/mis.branch 4896.55) cache accesses:      33976 (failure       3957)
 stage 1 runs at 0.88 cycles per input byte.
stage 1 instructions:    4581789 cycles:    1493930 (37.67 %) ins/cycles: 3.07 mis. branches:        309 (cycles/mis.branch 4833.16) cache accesses:      34449 (failure       3852)
 stage 1 runs at 0.86 cycles per input byte.

jsonexamples/github_events.json
-----current master:
stage 1 instructions:     179212 cycles:      48109 (46.64 %) ins/cycles: 3.73 mis. branches:         11 (cycles/mis.branch 4214.19) cache accesses:        121 (failure          0)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:     179212 cycles:      48148 (45.53 %) ins/cycles: 3.72 mis. branches:          9 (cycles/mis.branch 4943.89) cache accesses:        180 (failure          0)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:     179212 cycles:      48150 (45.89 %) ins/cycles: 3.72 mis. branches:         10 (cycles/mis.branch 4640.58) cache accesses:        306 (failure          0)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:     179212 cycles:      48160 (45.44 %) ins/cycles: 3.72 mis. branches:         10 (cycles/mis.branch 4791.58) cache accesses:        310 (failure          0)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:     179212 cycles:      48229 (46.15 %) ins/cycles: 3.72 mis. branches:          7 (cycles/mis.branch 6463.28) cache accesses:        445 (failure          0)
 stage 1 runs at 0.74 cycles per input byte.
------new code:
stage 1 instructions:     170913 cycles:      46770 (45.71 %) ins/cycles: 3.65 mis. branches:         10 (cycles/mis.branch 4335.38) cache accesses:        268 (failure          0)
 stage 1 runs at 0.72 cycles per input byte.
stage 1 instructions:     170913 cycles:      46280 (45.07 %) ins/cycles: 3.69 mis. branches:         13 (cycles/mis.branch 3378.61) cache accesses:        234 (failure          0)
 stage 1 runs at 0.71 cycles per input byte.
stage 1 instructions:     170913 cycles:      45977 (44.27 %) ins/cycles: 3.72 mis. branches:         13 (cycles/mis.branch 3329.02) cache accesses:        301 (failure          0)
 stage 1 runs at 0.71 cycles per input byte.
stage 1 instructions:     170913 cycles:      46040 (45.30 %) ins/cycles: 3.71 mis. branches:          8 (cycles/mis.branch 5135.58) cache accesses:        230 (failure          0)
 stage 1 runs at 0.71 cycles per input byte.
stage 1 instructions:     170913 cycles:      46278 (44.79 %) ins/cycles: 3.69 mis. branches:         14 (cycles/mis.branch 3241.50) cache accesses:        208 (failure          0)
 stage 1 runs at 0.71 cycles per input byte.

jsonexamples/gsoc-2018.json
-----current master:
stage 1 instructions:    7437274 cycles:    3544491 (44.05 %) ins/cycles: 2.10 mis. branches:       5424 (cycles/mis.branch 653.40) cache accesses:      55955 (failure      23664)
 stage 1 runs at 1.07 cycles per input byte.
stage 1 instructions:    7437270 cycles:    3301385 (44.09 %) ins/cycles: 2.25 mis. branches:       5475 (cycles/mis.branch 602.89) cache accesses:      56166 (failure      20913)
 stage 1 runs at 0.99 cycles per input byte.
stage 1 instructions:    7437274 cycles:    3441404 (43.78 %) ins/cycles: 2.16 mis. branches:       5391 (cycles/mis.branch 638.30) cache accesses:      55978 (failure      24680)
 stage 1 runs at 1.03 cycles per input byte.
stage 1 instructions:    7437273 cycles:    3286578 (43.53 %) ins/cycles: 2.26 mis. branches:       5488 (cycles/mis.branch 598.79) cache accesses:      55985 (failure      21186)
 stage 1 runs at 0.99 cycles per input byte.
stage 1 instructions:    7437271 cycles:    3282110 (43.84 %) ins/cycles: 2.27 mis. branches:       5437 (cycles/mis.branch 603.65) cache accesses:      56151 (failure      20515)
 stage 1 runs at 0.99 cycles per input byte.
------new code:
stage 1 instructions:    7194939 cycles:    3197959 (43.82 %) ins/cycles: 2.25 mis. branches:       5692 (cycles/mis.branch 561.79) cache accesses:      56010 (failure      19171)
 stage 1 runs at 0.96 cycles per input byte.
stage 1 instructions:    7194934 cycles:    3261866 (44.17 %) ins/cycles: 2.21 mis. branches:       5663 (cycles/mis.branch 575.98) cache accesses:      56312 (failure      20666)
 stage 1 runs at 0.98 cycles per input byte.
stage 1 instructions:    7194940 cycles:    3303809 (42.78 %) ins/cycles: 2.18 mis. branches:       5809 (cycles/mis.branch 568.68) cache accesses:      55997 (failure      22730)
 stage 1 runs at 0.99 cycles per input byte.
stage 1 instructions:    7194940 cycles:    3334107 (43.57 %) ins/cycles: 2.16 mis. branches:       5703 (cycles/mis.branch 584.58) cache accesses:      56002 (failure      21735)
 stage 1 runs at 1.00 cycles per input byte.
stage 1 instructions:    7194940 cycles:    3223229 (43.72 %) ins/cycles: 2.23 mis. branches:       5682 (cycles/mis.branch 567.27) cache accesses:      55977 (failure      19508)
 stage 1 runs at 0.97 cycles per input byte.

jsonexamples/instruments.json
-----current master:
stage 1 instructions:     662927 cycles:     178048 (37.67 %) ins/cycles: 3.72 mis. branches:        116 (cycles/mis.branch 1528.33) cache accesses:       4803 (failure          1)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     662927 cycles:     179375 (37.90 %) ins/cycles: 3.70 mis. branches:        121 (cycles/mis.branch 1482.07) cache accesses:       4661 (failure          1)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     662927 cycles:     178626 (37.73 %) ins/cycles: 3.71 mis. branches:        121 (cycles/mis.branch 1468.66) cache accesses:       4767 (failure          1)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     662927 cycles:     178067 (37.91 %) ins/cycles: 3.72 mis. branches:        114 (cycles/mis.branch 1557.32) cache accesses:       4805 (failure          1)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     662927 cycles:     178561 (37.86 %) ins/cycles: 3.71 mis. branches:        137 (cycles/mis.branch 1301.97) cache accesses:       4650 (failure          1)
 stage 1 runs at 0.81 cycles per input byte.
------new code:
stage 1 instructions:     627913 cycles:     168472 (36.61 %) ins/cycles: 3.73 mis. branches:        227 (cycles/mis.branch 741.48) cache accesses:       4671 (failure          1)
 stage 1 runs at 0.76 cycles per input byte.
stage 1 instructions:     627913 cycles:     168589 (36.82 %) ins/cycles: 3.72 mis. branches:        228 (cycles/mis.branch 739.12) cache accesses:       4744 (failure          1)
 stage 1 runs at 0.77 cycles per input byte.
stage 1 instructions:     627913 cycles:     168239 (36.76 %) ins/cycles: 3.73 mis. branches:        218 (cycles/mis.branch 769.58) cache accesses:       4670 (failure          1)
 stage 1 runs at 0.76 cycles per input byte.
stage 1 instructions:     627913 cycles:     168345 (36.61 %) ins/cycles: 3.73 mis. branches:        219 (cycles/mis.branch 768.69) cache accesses:       4730 (failure          1)
 stage 1 runs at 0.76 cycles per input byte.
stage 1 instructions:     627913 cycles:     168551 (36.56 %) ins/cycles: 3.73 mis. branches:        213 (cycles/mis.branch 789.01) cache accesses:       4652 (failure          0)
 stage 1 runs at 0.76 cycles per input byte.

jsonexamples/marine_ik.json
-----current master:
stage 1 instructions:   10994837 cycles:    4771425 (16.43 %) ins/cycles: 2.30 mis. branches:       5787 (cycles/mis.branch 824.41) cache accesses:      82867 (failure      59137)
 stage 1 runs at 1.60 cycles per input byte.
stage 1 instructions:   10994824 cycles:    4894695 (17.53 %) ins/cycles: 2.25 mis. branches:       5797 (cycles/mis.branch 844.31) cache accesses:      83379 (failure      57114)
 stage 1 runs at 1.64 cycles per input byte.
stage 1 instructions:   10994869 cycles:    4892159 (17.12 %) ins/cycles: 2.25 mis. branches:       5903 (cycles/mis.branch 828.74) cache accesses:      80760 (failure      60235)
 stage 1 runs at 1.64 cycles per input byte.
stage 1 instructions:   10994841 cycles:    4862415 (16.70 %) ins/cycles: 2.26 mis. branches:       5764 (cycles/mis.branch 843.45) cache accesses:      82627 (failure      61974)
 stage 1 runs at 1.63 cycles per input byte.
stage 1 instructions:   10994830 cycles:    4894870 (16.61 %) ins/cycles: 2.25 mis. branches:       5789 (cycles/mis.branch 845.55) cache accesses:      83018 (failure      66430)
 stage 1 runs at 1.64 cycles per input byte.
------new code:
stage 1 instructions:   10158210 cycles:    4620236 (16.80 %) ins/cycles: 2.20 mis. branches:       8236 (cycles/mis.branch 560.95) cache accesses:      83741 (failure      61448)
 stage 1 runs at 1.55 cycles per input byte.
stage 1 instructions:   10158228 cycles:    4671741 (16.70 %) ins/cycles: 2.17 mis. branches:       8240 (cycles/mis.branch 566.93) cache accesses:      82847 (failure      60551)
 stage 1 runs at 1.57 cycles per input byte.
stage 1 instructions:   10158224 cycles:    4849909 (16.73 %) ins/cycles: 2.09 mis. branches:       8202 (cycles/mis.branch 591.30) cache accesses:      82845 (failure      63452)
 stage 1 runs at 1.63 cycles per input byte.
stage 1 instructions:   10158234 cycles:    4731317 (16.00 %) ins/cycles: 2.15 mis. branches:       8292 (cycles/mis.branch 570.53) cache accesses:      82399 (failure      65669)
 stage 1 runs at 1.59 cycles per input byte.
stage 1 instructions:   10158220 cycles:    4672391 (16.26 %) ins/cycles: 2.17 mis. branches:       8144 (cycles/mis.branch 573.67) cache accesses:      83365 (failure      63810)
 stage 1 runs at 1.57 cycles per input byte.

jsonexamples/mesh.json
-----current master:
stage 1 instructions:    2529297 cycles:     677671 (20.90 %) ins/cycles: 3.73 mis. branches:        399 (cycles/mis.branch 1697.16) cache accesses:      20960 (failure         39)
 stage 1 runs at 0.94 cycles per input byte.
stage 1 instructions:    2529297 cycles:     675099 (20.88 %) ins/cycles: 3.75 mis. branches:        383 (cycles/mis.branch 1759.30) cache accesses:      20962 (failure         19)
 stage 1 runs at 0.93 cycles per input byte.
stage 1 instructions:    2529297 cycles:     677792 (20.91 %) ins/cycles: 3.73 mis. branches:        387 (cycles/mis.branch 1749.70) cache accesses:      20957 (failure         38)
 stage 1 runs at 0.94 cycles per input byte.
stage 1 instructions:    2529297 cycles:     675925 (20.89 %) ins/cycles: 3.74 mis. branches:        393 (cycles/mis.branch 1717.37) cache accesses:      20958 (failure         22)
 stage 1 runs at 0.93 cycles per input byte.
stage 1 instructions:    2529297 cycles:     676582 (20.85 %) ins/cycles: 3.74 mis. branches:        385 (cycles/mis.branch 1756.91) cache accesses:      20969 (failure         55)
 stage 1 runs at 0.94 cycles per input byte.
------new code:
stage 1 instructions:    2360197 cycles:     630014 (19.73 %) ins/cycles: 3.75 mis. branches:        565 (cycles/mis.branch 1114.19) cache accesses:      20959 (failure         32)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    2360197 cycles:     629900 (19.70 %) ins/cycles: 3.75 mis. branches:        570 (cycles/mis.branch 1105.07) cache accesses:      20958 (failure         34)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    2360197 cycles:     629671 (19.67 %) ins/cycles: 3.75 mis. branches:        567 (cycles/mis.branch 1108.62) cache accesses:      20959 (failure         41)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    2360197 cycles:     634416 (19.64 %) ins/cycles: 3.72 mis. branches:        564 (cycles/mis.branch 1123.66) cache accesses:      20958 (failure        164)
 stage 1 runs at 0.88 cycles per input byte.
stage 1 instructions:    2360197 cycles:     634040 (19.74 %) ins/cycles: 3.72 mis. branches:        639 (cycles/mis.branch 991.05) cache accesses:      20959 (failure         59)
 stage 1 runs at 0.88 cycles per input byte.

jsonexamples/mesh.pretty.json
-----current master:
stage 1 instructions:    4588507 cycles:    1521469 (25.34 %) ins/cycles: 3.02 mis. branches:         36 (cycles/mis.branch 41570.20) cache accesses:      32449 (failure       4086)
 stage 1 runs at 0.96 cycles per input byte.
stage 1 instructions:    4588507 cycles:    1486747 (24.25 %) ins/cycles: 3.09 mis. branches:         38 (cycles/mis.branch 38417.26) cache accesses:      32444 (failure       3736)
 stage 1 runs at 0.94 cycles per input byte.
stage 1 instructions:    4588497 cycles:    1452801 (24.90 %) ins/cycles: 3.16 mis. branches:         37 (cycles/mis.branch 38433.89) cache accesses:      32961 (failure       3471)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    4588507 cycles:    1455089 (24.44 %) ins/cycles: 3.15 mis. branches:         40 (cycles/mis.branch 35928.15) cache accesses:      32447 (failure       3285)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    4588503 cycles:    1484288 (25.07 %) ins/cycles: 3.09 mis. branches:         39 (cycles/mis.branch 37576.91) cache accesses:      32615 (failure       4206)
 stage 1 runs at 0.94 cycles per input byte.
------new code:
stage 1 instructions:    4359713 cycles:    1446361 (23.72 %) ins/cycles: 3.01 mis. branches:         41 (cycles/mis.branch 34768.29) cache accesses:      32694 (failure       4085)
 stage 1 runs at 0.92 cycles per input byte.
stage 1 instructions:    4359718 cycles:    1419880 (23.66 %) ins/cycles: 3.07 mis. branches:         41 (cycles/mis.branch 34631.23) cache accesses:      32467 (failure       3576)
 stage 1 runs at 0.90 cycles per input byte.
stage 1 instructions:    4359706 cycles:    1425196 (24.01 %) ins/cycles: 3.06 mis. branches:         36 (cycles/mis.branch 38833.70) cache accesses:      33110 (failure       5333)
 stage 1 runs at 0.90 cycles per input byte.
stage 1 instructions:    4359709 cycles:    1478296 (23.45 %) ins/cycles: 2.95 mis. branches:         38 (cycles/mis.branch 38297.83) cache accesses:      32897 (failure       4697)
 stage 1 runs at 0.94 cycles per input byte.
stage 1 instructions:    4359718 cycles:    1452770 (23.83 %) ins/cycles: 3.00 mis. branches:         39 (cycles/mis.branch 36593.72) cache accesses:      32464 (failure       3969)
 stage 1 runs at 0.92 cycles per input byte.

jsonexamples/numbers.json
-----current master:
stage 1 instructions:     454758 cycles:     122742 (22.39 %) ins/cycles: 3.70 mis. branches:         66 (cycles/mis.branch 1850.48) cache accesses:       2650 (failure          0)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:     454758 cycles:     122108 (22.29 %) ins/cycles: 3.72 mis. branches:         71 (cycles/mis.branch 1705.24) cache accesses:       2817 (failure          0)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     454758 cycles:     122337 (22.38 %) ins/cycles: 3.72 mis. branches:         79 (cycles/mis.branch 1545.94) cache accesses:       2555 (failure          0)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     454758 cycles:     121922 (22.23 %) ins/cycles: 3.73 mis. branches:         64 (cycles/mis.branch 1895.80) cache accesses:       2635 (failure          0)
 stage 1 runs at 0.81 cycles per input byte.
stage 1 instructions:     454758 cycles:     122076 (22.49 %) ins/cycles: 3.73 mis. branches:         72 (cycles/mis.branch 1688.74) cache accesses:       2442 (failure          0)
 stage 1 runs at 0.81 cycles per input byte.
------new code:
stage 1 instructions:     430480 cycles:     116887 (21.38 %) ins/cycles: 3.68 mis. branches:        247 (cycles/mis.branch 472.75) cache accesses:       2748 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     430480 cycles:     116827 (21.74 %) ins/cycles: 3.68 mis. branches:        242 (cycles/mis.branch 481.07) cache accesses:       2350 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     430480 cycles:     123457 (22.58 %) ins/cycles: 3.49 mis. branches:        253 (cycles/mis.branch 487.72) cache accesses:       2526 (failure          0)
 stage 1 runs at 0.82 cycles per input byte.
stage 1 instructions:     430480 cycles:     117174 (21.32 %) ins/cycles: 3.67 mis. branches:        239 (cycles/mis.branch 489.70) cache accesses:       2885 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:     430480 cycles:     116694 (21.58 %) ins/cycles: 3.69 mis. branches:        238 (cycles/mis.branch 490.07) cache accesses:       2751 (failure          0)
 stage 1 runs at 0.78 cycles per input byte.

jsonexamples/random.json
-----current master:
stage 1 instructions:    2147567 cycles:     622973 (40.61 %) ins/cycles: 3.45 mis. branches:        768 (cycles/mis.branch 810.67) cache accesses:      13558 (failure          6)
 stage 1 runs at 1.22 cycles per input byte.
stage 1 instructions:    2147567 cycles:     629340 (40.54 %) ins/cycles: 3.41 mis. branches:        786 (cycles/mis.branch 799.68) cache accesses:      13549 (failure         58)
 stage 1 runs at 1.23 cycles per input byte.
stage 1 instructions:    2147567 cycles:     623645 (40.58 %) ins/cycles: 3.44 mis. branches:        783 (cycles/mis.branch 796.28) cache accesses:      13562 (failure          7)
 stage 1 runs at 1.22 cycles per input byte.
stage 1 instructions:    2147567 cycles:     623357 (40.66 %) ins/cycles: 3.45 mis. branches:        790 (cycles/mis.branch 788.91) cache accesses:      13560 (failure          6)
 stage 1 runs at 1.22 cycles per input byte.
stage 1 instructions:    2147567 cycles:     622874 (40.64 %) ins/cycles: 3.45 mis. branches:        762 (cycles/mis.branch 817.32) cache accesses:      13536 (failure          6)
 stage 1 runs at 1.22 cycles per input byte.
------new code:
stage 1 instructions:    2038397 cycles:     607856 (39.40 %) ins/cycles: 3.35 mis. branches:        914 (cycles/mis.branch 664.59) cache accesses:      13575 (failure         49)
 stage 1 runs at 1.19 cycles per input byte.
stage 1 instructions:    2038397 cycles:     599285 (39.62 %) ins/cycles: 3.40 mis. branches:        930 (cycles/mis.branch 644.25) cache accesses:      13572 (failure          8)
 stage 1 runs at 1.17 cycles per input byte.
stage 1 instructions:    2038397 cycles:     597954 (39.60 %) ins/cycles: 3.41 mis. branches:        898 (cycles/mis.branch 665.33) cache accesses:      13562 (failure          8)
 stage 1 runs at 1.17 cycles per input byte.
stage 1 instructions:    2038397 cycles:     598108 (39.63 %) ins/cycles: 3.41 mis. branches:        899 (cycles/mis.branch 665.30) cache accesses:      13560 (failure          6)
 stage 1 runs at 1.17 cycles per input byte.
stage 1 instructions:    2038397 cycles:     598775 (39.58 %) ins/cycles: 3.40 mis. branches:        907 (cycles/mis.branch 659.65) cache accesses:      13568 (failure          9)
 stage 1 runs at 1.17 cycles per input byte.

jsonexamples/twitterescaped.json
-----current master:
stage 1 instructions:    1588942 cycles:     441708 (21.91 %) ins/cycles: 3.60 mis. branches:        718 (cycles/mis.branch 614.40) cache accesses:      12322 (failure         10)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:    1588942 cycles:     440979 (21.87 %) ins/cycles: 3.60 mis. branches:        704 (cycles/mis.branch 625.79) cache accesses:      12314 (failure          6)
 stage 1 runs at 0.78 cycles per input byte.
stage 1 instructions:    1588942 cycles:     442596 (21.95 %) ins/cycles: 3.59 mis. branches:        748 (cycles/mis.branch 591.06) cache accesses:      12317 (failure          8)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:    1588942 cycles:     441717 (21.93 %) ins/cycles: 3.60 mis. branches:        728 (cycles/mis.branch 606.26) cache accesses:      12318 (failure          7)
 stage 1 runs at 0.79 cycles per input byte.
stage 1 instructions:    1588942 cycles:     441854 (21.93 %) ins/cycles: 3.60 mis. branches:        726 (cycles/mis.branch 608.37) cache accesses:      12318 (failure          8)
 stage 1 runs at 0.79 cycles per input byte.
------new code:
stage 1 instructions:    1495853 cycles:     416839 (20.86 %) ins/cycles: 3.59 mis. branches:        859 (cycles/mis.branch 484.79) cache accesses:      12319 (failure          9)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:    1495853 cycles:     416716 (20.86 %) ins/cycles: 3.59 mis. branches:        865 (cycles/mis.branch 481.41) cache accesses:      12317 (failure          7)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:    1495853 cycles:     416730 (20.91 %) ins/cycles: 3.59 mis. branches:        855 (cycles/mis.branch 487.14) cache accesses:      12320 (failure          7)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:    1495853 cycles:     417295 (20.84 %) ins/cycles: 3.58 mis. branches:        852 (cycles/mis.branch 489.39) cache accesses:      12322 (failure          9)
 stage 1 runs at 0.74 cycles per input byte.
stage 1 instructions:    1495853 cycles:     415890 (20.84 %) ins/cycles: 3.60 mis. branches:        834 (cycles/mis.branch 498.42) cache accesses:      12318 (failure          6)
 stage 1 runs at 0.74 cycles per input byte.

jsonexamples/twitter.json
-----current master:
stage 1 instructions:    1954568 cycles:     552065 (44.81 %) ins/cycles: 3.54 mis. branches:        717 (cycles/mis.branch 769.01) cache accesses:      13418 (failure          7)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    1954568 cycles:     550847 (44.64 %) ins/cycles: 3.55 mis. branches:        692 (cycles/mis.branch 794.96) cache accesses:      13411 (failure          6)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    1954568 cycles:     550895 (44.79 %) ins/cycles: 3.55 mis. branches:        698 (cycles/mis.branch 788.21) cache accesses:      13421 (failure          7)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    1954568 cycles:     551097 (44.73 %) ins/cycles: 3.55 mis. branches:        726 (cycles/mis.branch 758.17) cache accesses:      13419 (failure          8)
 stage 1 runs at 0.87 cycles per input byte.
stage 1 instructions:    1954568 cycles:     550869 (44.70 %) ins/cycles: 3.55 mis. branches:        695 (cycles/mis.branch 791.86) cache accesses:      13416 (failure          7)
 stage 1 runs at 0.87 cycles per input byte.
------new code:
stage 1 instructions:    1869542 cycles:     529333 (43.31 %) ins/cycles: 3.53 mis. branches:        973 (cycles/mis.branch 543.88) cache accesses:      13415 (failure          7)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:    1869542 cycles:     528527 (43.24 %) ins/cycles: 3.54 mis. branches:        953 (cycles/mis.branch 554.42) cache accesses:      13424 (failure         11)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:    1869542 cycles:     528743 (43.21 %) ins/cycles: 3.54 mis. branches:        969 (cycles/mis.branch 545.13) cache accesses:      13408 (failure          6)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:    1869542 cycles:     528465 (43.30 %) ins/cycles: 3.54 mis. branches:        960 (cycles/mis.branch 550.30) cache accesses:      13411 (failure          8)
 stage 1 runs at 0.84 cycles per input byte.
stage 1 instructions:    1869542 cycles:     528346 (43.11 %) ins/cycles: 3.54 mis. branches:        946 (cycles/mis.branch 557.97) cache accesses:      13418 (failure          7)
 stage 1 runs at 0.84 cycles per input byte.

jsonexamples/update-center.json
-----current master:
stage 1 instructions:    1596772 cycles:     458421 (37.00 %) ins/cycles: 3.48 mis. branches:       1459 (cycles/mis.branch 314.02) cache accesses:      12389 (failure          6)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1596772 cycles:     458676 (37.12 %) ins/cycles: 3.48 mis. branches:       1461 (cycles/mis.branch 313.84) cache accesses:      12373 (failure          6)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1596772 cycles:     459401 (37.15 %) ins/cycles: 3.48 mis. branches:       1471 (cycles/mis.branch 312.30) cache accesses:      12396 (failure          6)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1596772 cycles:     458879 (37.00 %) ins/cycles: 3.48 mis. branches:       1457 (cycles/mis.branch 314.83) cache accesses:      12386 (failure          9)
 stage 1 runs at 0.86 cycles per input byte.
stage 1 instructions:    1596772 cycles:     458753 (37.10 %) ins/cycles: 3.48 mis. branches:       1446 (cycles/mis.branch 317.12) cache accesses:      12388 (failure          9)
 stage 1 runs at 0.86 cycles per input byte.
------new code:
stage 1 instructions:    1508344 cycles:     424729 (35.31 %) ins/cycles: 3.55 mis. branches:       1721 (cycles/mis.branch 246.79) cache accesses:      12360 (failure          5)
 stage 1 runs at 0.80 cycles per input byte.
stage 1 instructions:    1508344 cycles:     424500 (35.38 %) ins/cycles: 3.55 mis. branches:       1743 (cycles/mis.branch 243.41) cache accesses:      12375 (failure          6)
 stage 1 runs at 0.80 cycles per input byte.
stage 1 instructions:    1508344 cycles:     424476 (35.38 %) ins/cycles: 3.55 mis. branches:       1720 (cycles/mis.branch 246.78) cache accesses:      12384 (failure          7)
 stage 1 runs at 0.80 cycles per input byte.
stage 1 instructions:    1508344 cycles:     424397 (35.19 %) ins/cycles: 3.55 mis. branches:       1723 (cycles/mis.branch 246.28) cache accesses:      12384 (failure          6)
 stage 1 runs at 0.80 cycles per input byte.
stage 1 instructions:    1508344 cycles:     424678 (35.26 %) ins/cycles: 3.55 mis. branches:       1722 (cycles/mis.branch 246.56) cache accesses:      12380 (failure          8)
 stage 1 runs at 0.80 cycles per input byte.
```