### PR TITLE
Don't duplicate find_structural_bits for final chunk

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -31,7 +31,7 @@
 #define ISALIGNED_N(ptr, n) (((uintptr_t)(ptr) & ((n)-1)) == 0)
 
 #ifdef _MSC_VER
-#define really_inline inline
+#define really_inline __forceinline
 #define never_inline __declspec(noinline)
 
 #define UNUSED


### PR DESCRIPTION
find_structural_bits right now has a big comment apologizing for duplicating code. This fixes that. It has to pass a lot of parameters, which is an annoyance, but it does make the logic easier to follow and modify, so it seems like a win.

On Windows, I had to fix really_inline to, well, really inline. Otherwise there was a minor perf degradation (consistently around 7% on my machine) because this did *not* get inlined. __forceinline appears to be supported since at *least* 2005.