### PR TITLE
Fix MSVC errors in runetime_dispatch2 branch

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -44,22 +44,22 @@
 #define unlikely(x) x
 #endif
 
+// For Visual Studio compilers, same-page buffer overrun is not fine.
+#define ALLOW_SAME_PAGE_BUFFER_OVERRUN false
+
 #else
 
 // For non-Visual Studio compilers, we may assume that same-page buffer overrun is fine.
-// However, it will make it difficult to be "valgrind clean".
-//#ifndef ALLOW_SAME_PAGE_BUFFER_OVERRUN
-//#define ALLOW_SAME_PAGE_BUFFER_OVERRUN true
-//#else
+// However, it will make it difficult to be "valgrind clean," so we still turn it off.
 #define ALLOW_SAME_PAGE_BUFFER_OVERRUN false
-//#endif 
 
 // The following is likely unnecessarily complex.
 #ifdef __SANITIZE_ADDRESS__
 // we have GCC, stuck with https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67368
-#undef ALLOW_SAME_PAGE_BUFFER_OVERRUN
+#define ALLOW_SAME_PAGE_BUFFER_OVERRUN false
 #elif defined(__has_feature)
 // we have CLANG?
+// XXX if we're setting ALLOW_SAME_PAGE_BUFFER_OVERRUN to false, why do we have a non-empty qualifier?
 #  if (__has_feature(address_sanitizer))
 #define ALLOW_SAME_PAGE_BUFFER_OVERRUN_QUALIFIER  __attribute__((no_sanitize("address")))
 #  endif 

--- a/include/simdjson/jsonparser.h
+++ b/include/simdjson/jsonparser.h
@@ -36,7 +36,7 @@ int json_parse_implementation(const uint8_t *buf, size_t len, ParsedJson &pj, bo
   }
   bool reallocated = false;
   if(reallocifneeded) {
-#ifdef ALLOW_SAME_PAGE_BUFFER_OVERRUN
+#if ALLOW_SAME_PAGE_BUFFER_OVERRUN
     // realloc is needed if the end of the memory crosses a page
 #ifdef _MSC_VER
     SYSTEM_INFO sysInfo; 

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -19,6 +19,9 @@ _Pragma("GCC push_options") \
 _Pragma(STRINGIFY(GCC target(T)))
 #define UNTARGET_REGION \
 _Pragma("GCC pop_options")
+#else
+#define TARGET_REGION(T)
+#define UNTARGET_REGION
 #endif
 
 #define TARGET_HASWELL TARGET_REGION("avx2,bmi,pclmul")

--- a/include/simdjson/simddetection.h
+++ b/include/simdjson/simddetection.h
@@ -92,7 +92,7 @@ static inline uint32_t detect_supported_architectures()
 static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx)
 {
 #if defined(_MSC_VER)
-  uint32_t cpuInfo[4];
+  int cpuInfo[4];
   __cpuid(cpuInfo, *eax);
   *eax = cpuInfo[0];
   *ebx = cpuInfo[1];

--- a/src/stage2_build_tape.cpp
+++ b/src/stage2_build_tape.cpp
@@ -23,8 +23,8 @@ namespace simdjson {
     goto array_continue;                                                       \
   } else if (pj.ret_address[depth] == 'o') {                                   \
     goto object_continue;                                                      \
-  } else goto {                                                                \
-    start_continue;                                                            \
+  } else {                                                                     \
+    goto start_continue;                                                       \
   }                                                                            \
 }
 #endif 


### PR DESCRIPTION
This fixes the dynamic dispatch branch under MSVC (at least Visual Studio 19).

The only bit that puzzled me is whether [`ALLOW_SAME_PAGE_BUFFER_OVERRUN_QUALIFIER`](https://github.com/lemire/simdjson/compare/runtime_dispatch2...jkeiser:runtime_dispatch2_msvc?expand=1#diff-c3347f5cdf95839d7cf289466652933bR62) should be set ... given that we never appear to set ALLOW_SAME_PAGER_BUFFER_OVERRUN to true, it seemed weird that we would set this sometimes.

Hope this helps!