### PR TITLE
Replace macros with include files for better debugging

### DIFF
--- a/include/simdjson/stage1_find_marks.h
+++ b/include/simdjson/stage1_find_marks.h
@@ -115,10 +115,10 @@ really_inline uint64_t finalize_structurals(
 }
 
 template<architecture T = architecture::native>
-int find_structural_bits(const uint8_t *buf, size_t len, simdjson::ParsedJson &pj);
+int find_structural_bits(const uint8_t *buf, size_t len, ParsedJson &pj);
 
 template<architecture T = architecture::native>
-int find_structural_bits(const char *buf, size_t len, simdjson::ParsedJson &pj) {
+int find_structural_bits(const char *buf, size_t len, ParsedJson &pj) {
   return find_structural_bits((const uint8_t*)buf, len, pj);
 }
 

--- a/include/simdjson/stage1_find_marks_arm64.h
+++ b/include/simdjson/stage1_find_marks_arm64.h
@@ -2,7 +2,6 @@
 #define SIMDJSON_STAGE1_FIND_MARKS_ARM64_H
 
 #include "simdjson/stage1_find_marks.h"
-#include "simdjson/stage1_find_marks_macros.h"
 #include "simdjson/stage1_find_marks_flatten.h"
 #include "simdjson/simdutf8check_arm64.h"
 
@@ -192,6 +191,10 @@ void find_whitespace_and_structurals<architecture::arm64>(
   whitespace = neonmovemask_bulk(tmp_ws_0, tmp_ws_1, tmp_ws_2, tmp_ws_3);
 }
 }// simdjson namespace
+
+#define IMPL_TARGET_REGION TARGET_ARM64
+#define IMPL_ARCHITECTURE architecture::arm64
+#include "./stage1_find_marks_impl.h"
 
 #endif // IS_ARM64
 #endif // SIMDJSON_STAGE1_FIND_MARKS_ARM64_H

--- a/include/simdjson/stage1_find_marks_haswell.h
+++ b/include/simdjson/stage1_find_marks_haswell.h
@@ -2,7 +2,6 @@
 #define SIMDJSON_STAGE1_FIND_MARKS_HASWELL_H
 
 #include "simdjson/stage1_find_marks.h"
-#include "simdjson/stage1_find_marks_macros.h"
 #include "simdjson/stage1_find_marks_flatten.h"
 #include "simdjson/simdutf8check_haswell.h"
 
@@ -67,7 +66,7 @@ void check_utf8<architecture::haswell>(simd_input<architecture::haswell> in,
 
 template<> really_inline
 errorValues check_utf8_errors<architecture::haswell>(utf8_checking_state<architecture::haswell>& state) {
-  return _mm256_testz_si256(state.has_error, state.has_error) == 0 ? simdjson::UTF8_ERROR : simdjson::SUCCESS;
+  return _mm256_testz_si256(state.has_error, state.has_error) == 0 ? UTF8_ERROR : SUCCESS;
 }
 
 template<> really_inline
@@ -88,17 +87,6 @@ uint64_t unsigned_lteq_against_input<architecture::haswell>(simd_input<architect
   __m256i cmp_res_1 = _mm256_cmpeq_epi8(_mm256_max_epu8(maxval,in.hi),maxval);
   uint64_t res_1 = _mm256_movemask_epi8(cmp_res_1);
   return res_0 | (res_1 << 32);
-}
-
-template<> really_inline
-uint64_t find_odd_backslash_sequences<architecture::haswell>(simd_input<architecture::haswell> in, uint64_t &prev_iter_ends_odd_backslash) {
-  FIND_ODD_BACKSLASH_SEQUENCES(architecture::haswell, in, prev_iter_ends_odd_backslash);
-}
-
-template<> really_inline
-uint64_t find_quote_mask_and_bits<architecture::haswell>(simd_input<architecture::haswell> in, uint64_t odd_ends,
-    uint64_t &prev_iter_inside_quote, uint64_t &quote_bits, uint64_t &error_mask) {
-  FIND_QUOTE_MASK_AND_BITS(architecture::haswell, in, odd_ends, prev_iter_inside_quote, quote_bits, error_mask)
 }
 
 template<> really_inline
@@ -183,6 +171,10 @@ void find_whitespace_and_structurals<architecture::haswell>(simd_input<architect
 
 } // namespace simdjson
 UNTARGET_REGION
+
+#define IMPL_TARGET_REGION TARGET_HASWELL
+#define IMPL_ARCHITECTURE architecture::haswell
+#include "./stage1_find_marks_impl.h"
 
 
 #endif // IS_X86_64

--- a/include/simdjson/stage1_find_marks_impl.h
+++ b/include/simdjson/stage1_find_marks_impl.h
@@ -1,0 +1,224 @@
+
+// This is included *multiple times,* once per architecture, from stage1_find_marks.cpp
+
+#define S2(x) #x
+#define S(x) S2(x)
+#pragma message("Including " S(IMPL_TARGET_REGION) " / " S(IMPL_ARCHITECTURE))
+
+
+IMPL_TARGET_REGION
+namespace simdjson {
+
+  // return a bitvector indicating where we have characters that end an odd-length
+  // sequence of backslashes (and thus change the behavior of the next character
+  // to follow). A even-length sequence of backslashes, and, for that matter, the
+  // largest even-length prefix of our odd-length sequence of backslashes, simply
+  // modify the behavior of the backslashes themselves.
+  // We also update the prev_iter_ends_odd_backslash reference parameter to
+  // indicate whether we end an iteration on an odd-length sequence of
+  // backslashes, which modifies our subsequent search for odd-length
+  // sequences of backslashes in an obvious way.
+  // We need to compile that code for multiple architectures. However, target attributes can be used
+  // only once by function definition. Huge macro seemed better than huge code duplication.
+  // uint64_t FIND_ODD_BACKSLASH_SEQUENCES(architecture T, simd_input<T> in, uint64_t &prev_iter_ends_odd_backslash)
+  template<> really_inline
+  uint64_t find_odd_backslash_sequences<IMPL_ARCHITECTURE>(simd_input<IMPL_ARCHITECTURE> in, uint64_t & prev_iter_ends_odd_backslash) {
+    const uint64_t even_bits = 0x5555555555555555ULL;
+    const uint64_t odd_bits = ~even_bits;
+    uint64_t bs_bits = cmp_mask_against_input<IMPL_ARCHITECTURE>(in, '\\');
+    uint64_t start_edges = bs_bits & ~(bs_bits << 1);
+    /* flip lowest if we have an odd-length run at the end of the prior        */
+    /* iteration                                                               */
+    uint64_t even_start_mask = even_bits ^ prev_iter_ends_odd_backslash;
+    uint64_t even_starts = start_edges & even_start_mask;
+    uint64_t odd_starts = start_edges & ~even_start_mask;
+    uint64_t even_carries = bs_bits + even_starts;
+
+    uint64_t odd_carries;
+    /* must record the carry-out of our odd-carries out of bit 63; this        */
+    /* indicates whether the sense of any edge going to the next iteration     */
+    /* should be flipped                                                       */
+    bool iter_ends_odd_backslash =
+        add_overflow(bs_bits, odd_starts, &odd_carries);
+
+    odd_carries |=
+        prev_iter_ends_odd_backslash;  /* push in bit zero as a potential end  */
+                                      /* if we had an odd-numbered run at the */
+                                      /* end of the previous iteration        */
+    prev_iter_ends_odd_backslash = iter_ends_odd_backslash ? 0x1ULL : 0x0ULL;
+    uint64_t even_carry_ends = even_carries & ~bs_bits;
+    uint64_t odd_carry_ends = odd_carries & ~bs_bits;
+    uint64_t even_start_odd_end = even_carry_ends & odd_bits;
+    uint64_t odd_start_even_end = odd_carry_ends & even_bits;
+    uint64_t odd_ends = even_start_odd_end | odd_start_even_end;
+    return odd_ends;
+  }
+
+  // return both the quote mask (which is a half-open mask that covers the first
+  // quote
+  // in an unescaped quote pair and everything in the quote pair) and the quote
+  // bits, which are the simple
+  // unescaped quoted bits. We also update the prev_iter_inside_quote value to
+  // tell the next iteration
+  // whether we finished the final iteration inside a quote pair; if so, this
+  // inverts our behavior of
+  // whether we're inside quotes for the next iteration.
+  // Note that we don't do any error checking to see if we have backslash
+  // sequences outside quotes; these
+  // backslash sequences (of any length) will be detected elsewhere.
+  // We need to compile that code for multiple architectures. However, target attributes can be used
+  // only once by function definition. Huge macro seemed better than huge code duplication.
+  // uint64_t FIND_QUOTE_MASK_AND_BITS(architecture T, simd_input<T> in, uint64_t odd_ends,
+  //    uint64_t &prev_iter_inside_quote, uint64_t &quote_bits, uint64_t &error_mask)
+  template<> really_inline
+  uint64_t find_quote_mask_and_bits<IMPL_ARCHITECTURE>(simd_input<IMPL_ARCHITECTURE> in, uint64_t odd_ends, uint64_t & prev_iter_inside_quote, uint64_t & quote_bits, uint64_t & error_mask) {
+    quote_bits = cmp_mask_against_input<IMPL_ARCHITECTURE>(in, '"');
+    quote_bits = quote_bits & ~odd_ends;
+    uint64_t quote_mask = compute_quote_mask<IMPL_ARCHITECTURE>(quote_bits);
+    quote_mask ^= prev_iter_inside_quote;
+    /* All Unicode characters may be placed within the                                                */
+    /* quotation marks, except for the characters that MUST be escaped:                               */
+    /* quotation mark, reverse solidus, and the control characters (U+0000                            */
+    /*through U+001F).                                                                                */
+    /* https://tools.ietf.org/html/rfc8259                                                            */
+    uint64_t unescaped = unsigned_lteq_against_input<IMPL_ARCHITECTURE>(in, 0x1F);
+    error_mask |= quote_mask & unescaped;
+    /* right shift of a signed value expected to be well-defined and standard                         */
+    /* compliant as of C++20,                                                                         */
+    /* John Regher from Utah U. says this is fine code                                                */
+    prev_iter_inside_quote =
+        static_cast<uint64_t>(static_cast<int64_t>(quote_mask) >> 63);
+    return quote_mask;
+  }
+
+  template<>
+  int find_structural_bits<IMPL_ARCHITECTURE>(const uint8_t *buf, size_t len, ParsedJson &pj) {
+    if (len > pj.bytecapacity) {
+      std::cerr << "Your ParsedJson object only supports documents up to "
+          << pj.bytecapacity << " bytes but you are trying to process " << len
+          << " bytes" << std::endl;
+      return CAPACITY;
+    }
+    uint32_t *base_ptr = pj.structural_indexes;
+    uint32_t base = 0;
+    utf8_checking_state<IMPL_ARCHITECTURE> state;
+
+    /* we have padded the input out to 64 byte multiple with the remainder being                   */
+    /* zeros                                                                                       */
+
+    /* persistent state across loop                                                                */
+    /* does the last iteration end with an odd-length sequence of backslashes?                     */
+    /* either 0 or 1, but a 64-bit value                                                           */
+    uint64_t prev_iter_ends_odd_backslash = 0ULL;
+    /* does the previous iteration end inside a double-quote pair?                                 */
+    uint64_t prev_iter_inside_quote = 0ULL;  /* either all zeros or all ones                       */
+    /* does the previous iteration end on something that is a predecessor of a                     */
+    /* pseudo-structural character - i.e. whitespace or a structural character                     */
+    /* effectively the very first char is considered to follow "whitespace" for                    */
+    /* the                                                                                         */
+    /* purposes of pseudo-structural character detection so we initialize to 1                     */
+    uint64_t prev_iter_ends_pseudo_pred = 1ULL;
+
+    /* structurals are persistent state across loop as we flatten them on the                      */
+    /* subsequent iteration into our array pointed to be base_ptr.                                 */
+    /* This is harmless on the first iteration as structurals==0                                   */
+    /* and is done for performance reasons; we can hide some of the latency of the                 */
+    /* expensive carryless multiply in the previous step with this work                            */
+    uint64_t structurals = 0;
+
+    size_t lenminus64 = len < 64 ? 0 : len - 64;
+    size_t idx = 0;
+    uint64_t error_mask = 0; /* for unescaped characters within strings (ASCII code points < 0x20) */
+
+    for (; idx < lenminus64; idx += 64) {
+
+      simd_input<IMPL_ARCHITECTURE> in = fill_input<IMPL_ARCHITECTURE>(buf+idx);
+      check_utf8<IMPL_ARCHITECTURE>(in, state);
+      /* detect odd sequences of backslashes                                                       */
+      uint64_t odd_ends = find_odd_backslash_sequences<IMPL_ARCHITECTURE>(
+          in, prev_iter_ends_odd_backslash);
+
+      /* detect insides of quote pairs ("quote_mask") and also our quote_bits                      */
+      /* themselves                                                                                */
+      uint64_t quote_bits;
+      uint64_t quote_mask = find_quote_mask_and_bits<IMPL_ARCHITECTURE>(
+          in, odd_ends, prev_iter_inside_quote, quote_bits, error_mask);
+
+      /* take the previous iterations structural bits, not our current iteration,                  */
+      /* and flatten                                                                               */
+      flatten_bits(base_ptr, base, idx, structurals);
+
+      uint64_t whitespace;
+      find_whitespace_and_structurals<IMPL_ARCHITECTURE>(in, whitespace, structurals);
+
+      /* fixup structurals to reflect quotes and add pseudo-structural characters                  */
+      structurals = finalize_structurals(structurals, whitespace, quote_mask,
+                                        quote_bits, prev_iter_ends_pseudo_pred);
+    }
+
+    /*//////////////                                                                               */
+    /*/ we use a giant copy-paste which is ugly.                                                   */
+    /*/ but otherwise the string needs to be properly padded or else we                            */
+    /*/ risk invalidating the UTF-8 checks.                                                        */
+    /*//////////                                                                                   */
+    if (idx < len) {
+      uint8_t tmpbuf[64];
+      memset(tmpbuf, 0x20, 64);
+      memcpy(tmpbuf, buf + idx, len - idx);
+      simd_input<IMPL_ARCHITECTURE> in = fill_input<IMPL_ARCHITECTURE>(tmpbuf);
+      check_utf8<IMPL_ARCHITECTURE>(in, state);
+
+      /* detect odd sequences of backslashes                                                       */
+      uint64_t odd_ends = find_odd_backslash_sequences<IMPL_ARCHITECTURE>(
+          in, prev_iter_ends_odd_backslash);
+
+      /* detect insides of quote pairs ("quote_mask") and also our quote_bits                      */
+      /* themselves                                                                                */
+      uint64_t quote_bits;
+      uint64_t quote_mask = find_quote_mask_and_bits<IMPL_ARCHITECTURE>(
+          in, odd_ends, prev_iter_inside_quote, quote_bits, error_mask);
+
+      /* take the previous iterations structural bits, not our current iteration,                  */
+      /* and flatten                                                                               */
+      flatten_bits(base_ptr, base, idx, structurals);
+
+      uint64_t whitespace;
+      find_whitespace_and_structurals<IMPL_ARCHITECTURE>(in, whitespace, structurals);
+
+      /* fixup structurals to reflect quotes and add pseudo-structural characters                  */
+      structurals = finalize_structurals(structurals, whitespace, quote_mask,
+                                        quote_bits, prev_iter_ends_pseudo_pred);
+      idx += 64;
+    }
+
+    /* is last string quote closed?                                                                */
+    if (prev_iter_inside_quote) {
+        return UNCLOSED_STRING;
+    }
+
+    /* finally, flatten out the remaining structurals from the last iteration                      */
+    flatten_bits(base_ptr, base, idx, structurals);
+
+    pj.n_structural_indexes = base;
+    /* a valid JSON file cannot have zero structural indexes - we should have                      */
+    /* found something                                                                             */
+    if (pj.n_structural_indexes == 0u) {
+      return EMPTY;
+    }
+    if (base_ptr[pj.n_structural_indexes - 1] > len) {
+      return UNEXPECTED_ERROR;
+    }
+    if (len != base_ptr[pj.n_structural_indexes - 1]) {
+      /* the string might not be NULL terminated, but we add a virtual NULL ending                 */
+      /* character.                                                                                */
+      base_ptr[pj.n_structural_indexes++] = len;
+    }
+    /* make it safe to dereference one beyond this array                                           */
+    base_ptr[pj.n_structural_indexes] = 0;
+    if (error_mask) {
+      return UNESCAPED_CHARS;
+    }
+    return check_utf8_errors<IMPL_ARCHITECTURE>(state);
+  }                                                                                                   
+}
+UNTARGET_REGION

--- a/include/simdjson/stage1_find_marks_westmere.h
+++ b/include/simdjson/stage1_find_marks_westmere.h
@@ -1,12 +1,11 @@
 #ifndef SIMDJSON_STAGE1_FIND_MARKS_WESTMERE_H
 #define SIMDJSON_STAGE1_FIND_MARKS_WESTMERE_H
 
+#ifdef IS_X86_64
+
 #include "simdjson/stage1_find_marks.h"
-#include "simdjson/stage1_find_marks_macros.h"
 #include "simdjson/stage1_find_marks_flatten.h"
 #include "simdjson/simdutf8check_westmere.h"
-
-#ifdef IS_X86_64
 
 TARGET_WESTMERE
 namespace simdjson {
@@ -78,7 +77,7 @@ void check_utf8<architecture::westmere>(simd_input<architecture::westmere> in,
 
 template<> really_inline
 errorValues check_utf8_errors<architecture::westmere>(utf8_checking_state<architecture::westmere>& state) {
-  return _mm_testz_si128(state.has_error, state.has_error) == 0 ? simdjson::UTF8_ERROR : simdjson::SUCCESS;
+  return _mm_testz_si128(state.has_error, state.has_error) == 0 ? UTF8_ERROR : SUCCESS;
 }
 
 template<> really_inline
@@ -107,17 +106,6 @@ uint64_t unsigned_lteq_against_input<architecture::westmere>(simd_input<architec
   __m128i cmp_res_3 = _mm_cmpeq_epi8(_mm_max_epu8(maxval,in.v3),maxval);
   uint64_t res_3 = _mm_movemask_epi8(cmp_res_3);
   return res_0 | (res_1 << 16) | (res_2 << 32) | (res_3 << 48);
-}
-
-template<> really_inline
-uint64_t find_odd_backslash_sequences<architecture::westmere>(simd_input<architecture::westmere> in, uint64_t &prev_iter_ends_odd_backslash) {
-  FIND_ODD_BACKSLASH_SEQUENCES(architecture::westmere, in, prev_iter_ends_odd_backslash);
-}
-
-template<> really_inline
-uint64_t find_quote_mask_and_bits<architecture::westmere>(simd_input<architecture::westmere> in, uint64_t odd_ends,
-    uint64_t &prev_iter_inside_quote, uint64_t &quote_bits, uint64_t &error_mask) {
-  FIND_QUOTE_MASK_AND_BITS(architecture::westmere, in, odd_ends, prev_iter_inside_quote, quote_bits, error_mask)
 }
 
 template<> really_inline
@@ -172,9 +160,12 @@ void find_whitespace_and_structurals<architecture::westmere>(simd_input<architec
   structurals = (structural_res_0 | (structural_res_1 << 16) | (structural_res_2 << 32) | (structural_res_3 << 48));
 }
 
-
 } // namespace simdjson
 UNTARGET_REGION
+
+#define IMPL_TARGET_REGION TARGET_WESTMERE
+#define IMPL_ARCHITECTURE architecture::westmere
+#include "./stage1_find_marks_impl.h"
 
 
 #endif // IS_X86_64

--- a/src/stage1_find_marks.cpp
+++ b/src/stage1_find_marks.cpp
@@ -1,37 +1,3 @@
-#include "simdjson/portability.h"
-
-
-#ifdef IS_X86_64
-
 #include "simdjson/stage1_find_marks_haswell.h"
 #include "simdjson/stage1_find_marks_westmere.h"
-TARGET_HASWELL
-namespace simdjson {
-template<>
-int find_structural_bits<architecture::haswell>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  FIND_STRUCTURAL_BITS(architecture::haswell, buf, len, pj);
-}
-} // simdjson
-UNTARGET_REGION
-
-TARGET_WESTMERE
-namespace simdjson {
-template<>
-int find_structural_bits<architecture::westmere>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  FIND_STRUCTURAL_BITS(architecture::westmere, buf, len, pj);
-}
-} // simdjson
-UNTARGET_REGION
-
-#endif
-
-
-#ifdef IS_ARM64
 #include "simdjson/stage1_find_marks_arm64.h"
-namespace simdjson {
-template<>
-int find_structural_bits<architecture::arm64>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  FIND_STRUCTURAL_BITS(architecture::arm64, buf, len, pj);
-}
-}
-#endif


### PR DESCRIPTION
The new macros make debugging really hard, at least on VS, because I can't get line #'s for compile errors. This fixes stage 1 with a technique that includes the same .h file multiple times, with different #defines, rather than using a macro.

I haven't had time to fix stage 2 as well, but wanted to get some testing on other platforms / thoughts.