### PR TITLE
Fix most warnings on VS2019

### DIFF
--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
   simdjson::padded_string p;
   try {
     simdjson::get_corpus(filename).swap(p);
-  } catch (const std::exception &e) { // caught by reference to base
+  } catch (const std::exception &) { // caught by reference to base
     std::cout << "Could not load the file " << filename << std::endl;
     return EXIT_FAILURE;
   }

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
   simdjson::padded_string p;
   try {
     simdjson::get_corpus(filename).swap(p);
-  } catch (const std::exception &e) { // caught by reference to base
+  } catch (const std::exception &) { // caught by reference to base
     std::cerr << "Could not load the file " << filename << std::endl;
     return EXIT_FAILURE;
   }

--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -7,6 +7,7 @@
 #include "simdjson/simdjson.h"
 #include <cinttypes>
 #include <cmath>
+#include <limits>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
@@ -107,9 +108,9 @@ public:
     explicit Iterator(ParsedJson &pj_);
     ~Iterator();
 
-    Iterator(const Iterator &o);
+    Iterator(const Iterator &o) noexcept;
 
-    Iterator(Iterator &&o);
+    Iterator(Iterator &&o) noexcept;
 
     inline bool is_ok() const;
 
@@ -167,7 +168,7 @@ public:
     // we're at "d"
     inline double get_double() const {
       if (location + 1 >= tape_length) {
-        return NAN; // default value in case of error
+        return std::numeric_limits<double>::quiet_NaN(); // default value in case of error
       }
       double answer;
       memcpy(&answer, &pj.tape[location + 1], sizeof(answer));

--- a/include/simdjson/simdutf8check_haswell.h
+++ b/include/simdjson/simdutf8check_haswell.h
@@ -41,7 +41,7 @@ static inline void avx_check_smaller_than_0xF4(__m256i current_bytes,
                                                __m256i *has_error) {
   // unsigned, saturates to 0 below max
   *has_error = _mm256_or_si256(
-      *has_error, _mm256_subs_epu8(current_bytes, _mm256_set1_epi8(0xF4)));
+      *has_error, _mm256_subs_epu8(current_bytes, _mm256_set1_epi8(0xF4u)));
 }
 
 static inline __m256i avx_continuation_lengths(__m256i high_nibbles) {
@@ -94,14 +94,14 @@ static inline void avx_check_first_continuation_max(__m256i current_bytes,
                                                     __m256i off1_current_bytes,
                                                     __m256i *has_error) {
   __m256i maskED =
-      _mm256_cmpeq_epi8(off1_current_bytes, _mm256_set1_epi8(0xED));
+      _mm256_cmpeq_epi8(off1_current_bytes, _mm256_set1_epi8(0xEDu));
   __m256i maskF4 =
-      _mm256_cmpeq_epi8(off1_current_bytes, _mm256_set1_epi8(0xF4));
+      _mm256_cmpeq_epi8(off1_current_bytes, _mm256_set1_epi8(0xF4u));
 
   __m256i badfollowED = _mm256_and_si256(
-      _mm256_cmpgt_epi8(current_bytes, _mm256_set1_epi8(0x9F)), maskED);
+      _mm256_cmpgt_epi8(current_bytes, _mm256_set1_epi8(0x9Fu)), maskED);
   __m256i badfollowF4 = _mm256_and_si256(
-      _mm256_cmpgt_epi8(current_bytes, _mm256_set1_epi8(0x8F)), maskF4);
+      _mm256_cmpgt_epi8(current_bytes, _mm256_set1_epi8(0x8Fu)), maskF4);
 
   *has_error =
       _mm256_or_si256(*has_error, _mm256_or_si256(badfollowED, badfollowF4));
@@ -119,31 +119,31 @@ static inline void avx_check_overlong(__m256i current_bytes,
                                       __m256i *has_error) {
   __m256i off1_hibits = push_last_byte_of_a_to_b(previous_hibits, hibits);
   __m256i initial_mins = _mm256_shuffle_epi8(
-      _mm256_setr_epi8(-128, -128, -128, -128, -128, -128, -128, -128, -128,
-                       -128, -128, -128, // 10xx => false
-                       0xC2, -128,       // 110x
-                       0xE1,             // 1110
-                       0xF1,             // 1111
-                       -128, -128, -128, -128, -128, -128, -128, -128, -128,
-                       -128, -128, -128, // 10xx => false
-                       0xC2, -128,       // 110x
-                       0xE1,             // 1110
-                       0xF1),            // 1111
+      _mm256_setr_epi8(-128,  -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128,  -128, -128, // 10xx => false
+                       0xC2u, -128,       // 110x
+                       0xE1u,             // 1110
+                       0xF1u,             // 1111
+                       -128,  -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128,  -128, -128, // 10xx => false
+                       0xC2u, -128,       // 110x
+                       0xE1u,             // 1110
+                       0xF1u),            // 1111
       off1_hibits);
 
   __m256i initial_under = _mm256_cmpgt_epi8(initial_mins, off1_current_bytes);
 
   __m256i second_mins = _mm256_shuffle_epi8(
-      _mm256_setr_epi8(-128, -128, -128, -128, -128, -128, -128, -128, -128,
-                       -128, -128, -128, // 10xx => false
-                       127, 127,         // 110x => true
-                       0xA0,             // 1110
-                       0x90,             // 1111
-                       -128, -128, -128, -128, -128, -128, -128, -128, -128,
-                       -128, -128, -128, // 10xx => false
-                       127, 127,         // 110x => true
-                       0xA0,             // 1110
-                       0x90),            // 1111
+      _mm256_setr_epi8(-128,  -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128,  -128, -128, // 10xx => false
+                       127,    127,       // 110x => true
+                       0xA0u,             // 1110
+                       0x90u,             // 1111
+                       -128,  -128, -128, -128, -128, -128, -128, -128, -128,
+                       -128,  -128, -128, // 10xx => false
+                       127,    127,       // 110x => true
+                       0xA0u,             // 1110
+                       0x90u),            // 1111
       off1_hibits);
   __m256i second_under = _mm256_cmpgt_epi8(second_mins, current_bytes);
   *has_error = _mm256_or_si256(*has_error,

--- a/include/simdjson/simdutf8check_westmere.h
+++ b/include/simdjson/simdutf8check_westmere.h
@@ -35,7 +35,7 @@ static inline void check_smaller_than_0xF4(__m128i current_bytes,
                                            __m128i *has_error) {
   // unsigned, saturates to 0 below max
   *has_error = _mm_or_si128(*has_error,
-                            _mm_subs_epu8(current_bytes, _mm_set1_epi8(0xF4)));
+                            _mm_subs_epu8(current_bytes, _mm_set1_epi8(0xF4u)));
 }
 
 static inline __m128i continuation_lengths(__m128i high_nibbles) {
@@ -80,13 +80,13 @@ static inline void check_continuations(__m128i initial_lengths, __m128i carries,
 static inline void check_first_continuation_max(__m128i current_bytes,
                                                 __m128i off1_current_bytes,
                                                 __m128i *has_error) {
-  __m128i maskED = _mm_cmpeq_epi8(off1_current_bytes, _mm_set1_epi8(0xED));
-  __m128i maskF4 = _mm_cmpeq_epi8(off1_current_bytes, _mm_set1_epi8(0xF4));
+  __m128i maskED = _mm_cmpeq_epi8(off1_current_bytes, _mm_set1_epi8(0xEDu));
+  __m128i maskF4 = _mm_cmpeq_epi8(off1_current_bytes, _mm_set1_epi8(0xF4u));
 
   __m128i badfollowED =
-      _mm_and_si128(_mm_cmpgt_epi8(current_bytes, _mm_set1_epi8(0x9F)), maskED);
+      _mm_and_si128(_mm_cmpgt_epi8(current_bytes, _mm_set1_epi8(0x9Fu)), maskED);
   __m128i badfollowF4 =
-      _mm_and_si128(_mm_cmpgt_epi8(current_bytes, _mm_set1_epi8(0x8F)), maskF4);
+      _mm_and_si128(_mm_cmpgt_epi8(current_bytes, _mm_set1_epi8(0x8Fu)), maskF4);
 
   *has_error = _mm_or_si128(*has_error, _mm_or_si128(badfollowED, badfollowF4));
 }
@@ -102,21 +102,21 @@ static inline void check_overlong(__m128i current_bytes,
                                   __m128i previous_hibits, __m128i *has_error) {
   __m128i off1_hibits = _mm_alignr_epi8(hibits, previous_hibits, 16 - 1);
   __m128i initial_mins = _mm_shuffle_epi8(
-      _mm_setr_epi8(-128, -128, -128, -128, -128, -128, -128, -128, -128, -128,
-                    -128, -128, // 10xx => false
-                    0xC2, -128, // 110x
-                    0xE1,       // 1110
-                    0xF1),
+      _mm_setr_epi8(-128,  -128, -128, -128, -128, -128, -128, -128, -128, -128,
+                    -128,  -128, // 10xx => false
+                    0xC2u, -128, // 110x
+                    0xE1u,       // 1110
+                    0xF1u),
       off1_hibits);
 
   __m128i initial_under = _mm_cmpgt_epi8(initial_mins, off1_current_bytes);
 
   __m128i second_mins = _mm_shuffle_epi8(
-      _mm_setr_epi8(-128, -128, -128, -128, -128, -128, -128, -128, -128, -128,
-                    -128, -128, // 10xx => false
-                    127, 127,   // 110x => true
-                    0xA0,       // 1110
-                    0x90),
+      _mm_setr_epi8(-128,  -128, -128, -128, -128, -128, -128, -128, -128, -128,
+                    -128,  -128, // 10xx => false
+                    127,    127, // 110x => true
+                    0xA0u,       // 1110
+                    0x90u),
       off1_hibits);
   __m128i second_under = _mm_cmpgt_epi8(second_mins, current_bytes);
   *has_error =

--- a/include/simdjson/stage1_find_marks.h
+++ b/include/simdjson/stage1_find_marks.h
@@ -11,7 +11,7 @@ namespace simdjson {
 
 template <Architecture> struct simd_input;
 
-template <Architecture T> uint64_t compute_quote_mask(uint64_t quote_bits);
+template <Architecture> uint64_t compute_quote_mask(uint64_t quote_bits);
 
 namespace {
 // for when clmul is unavailable

--- a/include/simdjson/stage1_find_marks_haswell.h
+++ b/include/simdjson/stage1_find_marks_haswell.h
@@ -30,7 +30,7 @@ compute_quote_mask<Architecture::HASWELL>(uint64_t quote_bits) {
   // There should be no such thing with a processing supporting avx2
   // but not clmul.
   uint64_t quote_mask = _mm_cvtsi128_si64(_mm_clmulepi64_si128(
-      _mm_set_epi64x(0ULL, quote_bits), _mm_set1_epi8(0xFF), 0));
+      _mm_set_epi64x(0ULL, quote_bits), _mm_set1_epi8(0xFFu), 0));
   return quote_mask;
 }
 
@@ -49,7 +49,7 @@ template <>
 really_inline void check_utf8<Architecture::HASWELL>(
     simd_input<Architecture::HASWELL> in,
     utf8_checking_state<Architecture::HASWELL> &state) {
-  __m256i high_bit = _mm256_set1_epi8(0x80);
+  __m256i high_bit = _mm256_set1_epi8(0x80u);
   if ((_mm256_testz_si256(_mm256_or_si256(in.lo, in.hi), high_bit)) == 1) {
     // it is ascii, we just check continuation
     state.has_error = _mm256_or_si256(
@@ -170,12 +170,12 @@ really_inline void find_whitespace_and_structurals<Architecture::HASWELL>(
 
 #else  // SIMDJSON_NAIVE_STRUCTURAL
   const __m256i structural_table =
-      _mm256_setr_epi8(44, 125, 0, 0, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123,
-                       44, 125, 0, 0, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123);
+      _mm256_setr_epi8(44, 125, 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123,
+                       44, 125, 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123);
   const __m256i white_table = _mm256_setr_epi8(
       32, 100, 100, 100, 17, 100, 113, 2, 100, 9, 10, 112, 100, 13, 100, 100,
       32, 100, 100, 100, 17, 100, 113, 2, 100, 9, 10, 112, 100, 13, 100, 100);
-  const __m256i struct_offset = _mm256_set1_epi8(0xd4);
+  const __m256i struct_offset = _mm256_set1_epi8(0xd4u);
   const __m256i struct_mask = _mm256_set1_epi8(32);
 
   __m256i lo_white =

--- a/include/simdjson/stage1_find_marks_westmere.h
+++ b/include/simdjson/stage1_find_marks_westmere.h
@@ -32,7 +32,7 @@ template <>
 really_inline uint64_t
 compute_quote_mask<Architecture::WESTMERE>(uint64_t quote_bits) {
   return _mm_cvtsi128_si64(_mm_clmulepi64_si128(
-      _mm_set_epi64x(0ULL, quote_bits), _mm_set1_epi8(0xFF), 0));
+      _mm_set_epi64x(0ULL, quote_bits), _mm_set1_epi8(0xFFu), 0));
 }
 
 template <> struct utf8_checking_state<Architecture::WESTMERE> {
@@ -48,7 +48,7 @@ template <>
 really_inline void check_utf8<Architecture::WESTMERE>(
     simd_input<Architecture::WESTMERE> in,
     utf8_checking_state<Architecture::WESTMERE> &state) {
-  __m128i high_bit = _mm_set1_epi8(0x80);
+  __m128i high_bit = _mm_set1_epi8(0x80u);
   if ((_mm_testz_si128(_mm_or_si128(in.v0, in.v1), high_bit)) == 1) {
     // it is ascii, we just check continuation
     state.has_error =
@@ -140,10 +140,10 @@ really_inline void find_whitespace_and_structurals<Architecture::WESTMERE>(
     simd_input<Architecture::WESTMERE> in, uint64_t &whitespace,
     uint64_t &structurals) {
   const __m128i structural_table =
-      _mm_setr_epi8(44, 125, 0, 0, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123);
+      _mm_setr_epi8(44, 125, 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123);
   const __m128i white_table = _mm_setr_epi8(32, 100, 100, 100, 17, 100, 113, 2,
                                             100, 9, 10, 112, 100, 13, 100, 100);
-  const __m128i struct_offset = _mm_set1_epi8(0xd4);
+  const __m128i struct_offset = _mm_set1_epi8(0xd4u);
   const __m128i struct_mask = _mm_set1_epi8(32);
 
   __m128i white0 = _mm_cmpeq_epi8(in.v0, _mm_shuffle_epi8(white_table, in.v0));

--- a/src/parsedjsoniterator.cpp
+++ b/src/parsedjsoniterator.cpp
@@ -34,7 +34,7 @@ ParsedJson::Iterator::Iterator(ParsedJson &pj_)
 
 ParsedJson::Iterator::~Iterator() { delete[] depth_index; }
 
-ParsedJson::Iterator::Iterator(const Iterator &o)
+ParsedJson::Iterator::Iterator(const Iterator &o) noexcept
     : pj(o.pj), depth(o.depth), location(o.location), tape_length(0),
       current_type(o.current_type), current_val(o.current_val),
       depth_index(nullptr) {
@@ -45,7 +45,7 @@ ParsedJson::Iterator::Iterator(const Iterator &o)
   tape_length = o.tape_length;
 }
 
-ParsedJson::Iterator::Iterator(Iterator &&o)
+ParsedJson::Iterator::Iterator(Iterator &&o) noexcept
     : pj(o.pj), depth(o.depth), location(o.location),
       tape_length(o.tape_length), current_type(o.current_type),
       current_val(o.current_val), depth_index(o.depth_index) {
@@ -114,7 +114,7 @@ bool ParsedJson::Iterator::move_to(const char *pointer, uint32_t length) {
           }
           new_pointer[new_length] = fragment;
           i += 3;
-        } catch (std::invalid_argument &e) {
+        } catch (std::invalid_argument &) {
           delete[] new_pointer;
           return false; // the fragment is invalid
         }

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -68,7 +68,7 @@ bool validate(const char *dirname) {
       simdjson::padded_string p;
       try {
         simdjson::get_corpus(fullpath).swap(p);
-      } catch (const std::exception &e) {
+      } catch (const std::exception &) {
         std::cerr << "Could not load the file " << fullpath << std::endl;
         return EXIT_FAILURE;
       }

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
   simdjson::padded_string p;
   try {
     simdjson::get_corpus(filename).swap(p);
-  } catch (const std::exception &e) { // caught by reference to base
+  } catch (const std::exception &) { // caught by reference to base
     std::cout << "Could not load the file " << filename << std::endl;
     return EXIT_FAILURE;
   }

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
   simdjson::padded_string p;
   try {
     simdjson::get_corpus(filename).swap(p);
-  } catch (const std::exception &e) { // caught by reference to base
+  } catch (const std::exception &) { // caught by reference to base
     std::cerr << "Could not load the file " << filename << std::endl;
     return EXIT_FAILURE;
   }

--- a/tools/minify.cpp
+++ b/tools/minify.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   std::string filename = argv[argc - 1];
   try {
     simdjson::get_corpus(filename).swap(p);
-  } catch (const std::exception &e) {
+  } catch (const std::exception &) {
     std::cout << "Could not load the file " << filename << std::endl;
     return EXIT_FAILURE;
   }


### PR DESCRIPTION
This fixes all the "obvious" warnings on VS2019: unused variables in the catch() statements, assigning const >= 128 to a signed byte, and a weird one that wanted `noexcept` in a couple of constructors for some reason (which I was happy to provide, since that's been around a while in C++).

Two warnings remain:

* It thinks there's a buffer overrun when depth_capacity is 1 [in parsedjsoniterator.cpp](https://github.com/lemire/simdjson/blob/master/src/parsedjsoniterator.cpp#L26):

  `Warning	C6386	Buffer overrun while writing to 'depth_index':  the writable size is 'pj.depth_capacity*16' bytes, but '32' bytes might be written.`
* C++ uses exceptions, but we haven't turned on unwind semantics with `/EHsc`. I'm not sure whether we *wanted* unwind semantics turned on, because I know they impact performance, so I haven't tried to resolve this one:

  `Warning	C4530	 C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc`
