### PR TITLE
preventing clang-format to move sysinfoapi.h

### DIFF
--- a/include/simdjson/jsonparser.h
+++ b/include/simdjson/jsonparser.h
@@ -10,7 +10,8 @@
 #include <string>
 #ifdef _MSC_VER
 #include <windows.h>
-#include <sysinfoapi.h> // must be included after windows.h
+// must be included after windows.h
+#include <sysinfoapi.h>
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
A simple change that prevents clang-format to automatically move sysinfoapi.h before windows.h.