### PR TITLE
Fix Intellisense errors opening .h files on VS2019

### DIFF
--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -27,16 +27,20 @@
 #define TARGET_REGION(T)                                                       \
   _Pragma("GCC push_options") _Pragma(STRINGIFY(GCC target(T)))
 #define UNTARGET_REGION _Pragma("GCC pop_options")
-#else
+#endif // clang then gcc
+
+#endif  // x86
+
+// Default target region macros don't do anything.
+#ifndef TARGET_REGION
 #define TARGET_REGION(T)
 #define UNTARGET_REGION
-#endif // clang then gcc
+#endif
 
 // under GCC and CLANG, we use these two macros
 #define TARGET_HASWELL TARGET_REGION("avx2,bmi,pclmul")
 #define TARGET_WESTMERE TARGET_REGION("sse4.2,pclmul")
-
-#endif // x86
+#define TARGET_ARM64
 
 #ifdef _MSC_VER
 #include <intrin.h>

--- a/include/simdjson/stage1_find_marks_common.h
+++ b/include/simdjson/stage1_find_marks_common.h
@@ -4,6 +4,10 @@
 // "simdjson/stage1_find_marks.h" (this simplifies amalgation)
 
 #ifdef TARGETED_ARCHITECTURE
+#ifdef TARGETED_REGION
+
+TARGETED_REGION
+namespace simdjson {
 
 // return a bitvector indicating where we have characters that end an odd-length
 // sequence of backslashes (and thus change the behavior of the next character
@@ -226,4 +230,12 @@ int find_structural_bits<TARGETED_ARCHITECTURE>(const uint8_t *buf, size_t len,
   return check_utf8_errors<TARGETED_ARCHITECTURE>(utf8_state);
 }
 
+} // namespace simdjson
+UNTARGET_REGION
+
+#else
+#error TARGETED_REGION must be specified before including.
+#endif // TARGETED_REGION
+#else
+#error TARGETED_ARCHITECTURE must be specified before including.
 #endif // TARGETED_ARCHITECTURE

--- a/include/simdjson/stage2_build_tape_common.h
+++ b/include/simdjson/stage2_build_tape_common.h
@@ -4,6 +4,11 @@
 // "simdjson/stage2_build_tape.h" (this simplifies amalgation)
 
 #ifdef TARGETED_ARCHITECTURE
+#ifdef TARGETED_REGION
+
+TARGETED_REGION
+namespace simdjson {
+
 // this macro reads the next structural character, updating idx, i and c.
 #define UPDATE_CHAR()                                                          \
   {                                                                            \
@@ -522,4 +527,12 @@ fail:
   return pj.error_code;
 }
 
+} // namespace simdjson
+UNTARGET_REGION
+
+#else
+#error TARGETED_REGION must be specified before including.
+#endif // TARGETED_REGION
+#else
+#error TARGETED_ARCHITECTURE must be specified before including.
 #endif // TARGETED_ARCHITECTURE

--- a/include/simdjson/stringparsing_arm64.h
+++ b/include/simdjson/stringparsing_arm64.h
@@ -41,10 +41,13 @@ find_bs_bits_and_quote_bits<Architecture::ARM64>(const uint8_t *src,
   };
 }
 
+} // namespace simdjson
+
 #define TARGETED_ARCHITECTURE Architecture::ARM64
+#define TARGETED_REGION TARGET_ARM64
 #include "simdjson/stringparsing_common.h"
 #undef TARGETED_ARCHITECTURE
+#undef TARGETED_REGION
 
-} // namespace simdjson
-#endif
+#endif // IS_ARM64
 #endif

--- a/include/simdjson/stringparsing_common.h
+++ b/include/simdjson/stringparsing_common.h
@@ -4,6 +4,11 @@
 // "simdjson/stringparsing.h" (this simplifies amalgation)
 
 #ifdef TARGETED_ARCHITECTURE
+#ifdef TARGETED_REGION
+
+TARGETED_REGION
+namespace simdjson {
+
 template <>
 WARN_UNUSED ALLOW_SAME_PAGE_BUFFER_OVERRUN_QUALIFIER LENIENT_MEM_SANITIZER
     really_inline bool
@@ -88,4 +93,12 @@ WARN_UNUSED ALLOW_SAME_PAGE_BUFFER_OVERRUN_QUALIFIER LENIENT_MEM_SANITIZER
   return true;
 }
 
+} // namespace simdjson
+UNTARGET_REGION
+
+#else
+#error TARGETED_REGION must be specified before including.
+#endif // TARGETED_REGION
+#else
+#error TARGETED_ARCHITECTURE must be specified before including.
 #endif // TARGETED_ARCHITECTURE

--- a/include/simdjson/stringparsing_haswell.h
+++ b/include/simdjson/stringparsing_haswell.h
@@ -24,13 +24,15 @@ find_bs_bits_and_quote_bits<Architecture::HASWELL>(const uint8_t *src,
       static_cast<uint32_t>(_mm256_movemask_epi8(quote_mask)) // quote_bits
   };
 }
-
-#define TARGETED_ARCHITECTURE Architecture::HASWELL
-#include "simdjson/stringparsing_common.h"
-#undef TARGETED_ARCHITECTURE
-
 } // namespace simdjson
 UNTARGET_REGION
-#endif
+
+#define TARGETED_ARCHITECTURE Architecture::HASWELL
+#define TARGETED_REGION TARGET_HASWELL
+#include "simdjson/stringparsing_common.h"
+#undef TARGETED_ARCHITECTURE
+#undef TARGETED_REGION
+
+#endif // IS_X86_64
 
 #endif

--- a/include/simdjson/stringparsing_westmere.h
+++ b/include/simdjson/stringparsing_westmere.h
@@ -23,13 +23,15 @@ find_bs_bits_and_quote_bits<Architecture::WESTMERE>(const uint8_t *src,
       static_cast<uint32_t>(_mm_movemask_epi8(quote_mask)) // quote_bits
   };
 }
-
-#define TARGETED_ARCHITECTURE Architecture::WESTMERE
-#include "simdjson/stringparsing_common.h"
-#undef TARGETED_ARCHITECTURE
-
 } // namespace simdjson
 UNTARGET_REGION
-#endif
+
+#define TARGETED_ARCHITECTURE Architecture::WESTMERE
+#define TARGETED_REGION TARGET_WESTMERE
+#include "simdjson/stringparsing_common.h"
+#undef TARGETED_ARCHITECTURE
+#undef TARGETED_REGION
+
+#endif // IS_X86_64
 
 #endif

--- a/src/stage1_find_marks.cpp
+++ b/src/stage1_find_marks.cpp
@@ -2,32 +2,32 @@
 #include "simdjson/portability.h"
 
 #ifdef IS_X86_64
+
 #include "simdjson/stage1_find_marks_haswell.h"
 #include "simdjson/stage1_find_marks_westmere.h"
 
-TARGET_HASWELL
-namespace simdjson {
 #define TARGETED_ARCHITECTURE Architecture::HASWELL
+#define TARGETED_REGION TARGET_HASWELL
 #include "simdjson/stage1_find_marks_common.h"
 #undef TARGETED_ARCHITECTURE
-} // namespace simdjson
-UNTARGET_REGION
+#undef TARGETED_REGION
 
-TARGET_WESTMERE
-namespace simdjson {
 #define TARGETED_ARCHITECTURE Architecture::WESTMERE
+#define TARGETED_REGION TARGET_WESTMERE
 #include "simdjson/stage1_find_marks_common.h"
 #undef TARGETED_ARCHITECTURE
-} // namespace simdjson
-UNTARGET_REGION
+#undef TARGETED_REGION
 
 #endif // IS_X86_64
 
 #ifdef IS_ARM64
+
 #include "simdjson/stage1_find_marks_arm64.h"
-namespace simdjson {
+
 #define TARGETED_ARCHITECTURE Architecture::ARM64
+#define TARGETED_REGION TARGET_ARM64
 #include "simdjson/stage1_find_marks_common.h"
 #undef TARGETED_ARCHITECTURE
-} // namespace simdjson
+#undef TARGETED_REGION
+
 #endif // IS_ARM64

--- a/src/stage2_build_tape.cpp
+++ b/src/stage2_build_tape.cpp
@@ -1,27 +1,23 @@
 #include "simdjson/stage2_build_tape.h"
 
 #ifdef IS_X86_64
-TARGET_HASWELL
-namespace simdjson {
 #define TARGETED_ARCHITECTURE Architecture::HASWELL
+#define TARGETED_REGION TARGET_HASWELL
 #include "simdjson/stage2_build_tape_common.h"
 #undef TARGETED_ARCHITECTURE
-} // namespace simdjson
-UNTARGET_REGION
+#undef TARGETED_REGION
 
-TARGET_WESTMERE
-namespace simdjson {
 #define TARGETED_ARCHITECTURE Architecture::WESTMERE
+#define TARGETED_REGION TARGET_WESTMERE
 #include "simdjson/stage2_build_tape_common.h"
 #undef TARGETED_ARCHITECTURE
-} // namespace simdjson
-UNTARGET_REGION
+#undef TARGETED_REGION
 #endif // IS_X86_64
 
 #ifdef IS_ARM64
-namespace simdjson {
 #define TARGETED_ARCHITECTURE Architecture::ARM64
+#define TARGETED_REGION TARGET_ARM64
 #include "simdjson/stage2_build_tape_common.h"
 #undef TARGETED_ARCHITECTURE
-} // namespace simdjson
-#endif
+#undef TARGETED_REGION
+#endif // IS_ARM64


### PR DESCRIPTION
This fixes the Visual Studio Intellisense errors by moving the namespace stuff into the .h file. Basically Intellisense wants to read the .h file by itself, without considering the fact that it might be included from within a `namespace {}` directive.

I'm not thrilled at having to pass two variables. I think there might be a way to avoid it by using a `template<> const char* REGION_TARGET<Architecture::WESTMERE> = "avx2,bmi,pclmul";` and use `TARGET_REGION(REGION_TARGET<TARGETED_ARCHITECTURE>)`, but I don't know if the pragma would support using a const char*.

If I get time to learn about [C++ Hint Files](https://docs.microsoft.com/en-us/cpp/build/reference/hint-files?view=vs-2019), that might be an alternate way to fix Intellisense without changing the codebase. But that has drawbacks too, and this seems to do the trick, at any rate.