### PR TITLE
Make Docker start much faster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+*
+!Makefile
+!amalgamation.sh
+!benchmark
+!dependencies
+!include
+!jsonchecker
+!jsonexamples
+!scripts
+!singleheader
+!src
+!style
+!tests
+!tools


### PR DESCRIPTION
Right now `docker build` is sending everything from .git and any other random subdirectory. This creates a whitelist that only sends in stuff we need. (NOTE: I'm not actually sure we even need all that, but this makes it fast enough I quit worrying about it :))