### PR TITLE
Bring .git into docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!.git
 !Makefile
 !amalgamation.sh
 !benchmark


### PR DESCRIPTION
I'm not sure how it was working on my machine, but .git is needed to bring in submodules. Docker is failing right now.

There are better ways to do the Dockerfile that don't copy so much (volume mounts), but right now I just want it to work :)) Even with .git it's WAY faster than before though, probably because of the VS folder on my machine or something. 40M transfer instead of 700M.