### PR TITLE
check for performance degradation in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,10 @@ steps:
   - make
   - make quiettest
   - make amalgamate
+- name: checkperf
+  image: gcc:8
+  commands:
+  - make checkperf
 ---
 kind: pipeline
 name: arm64
@@ -27,6 +31,10 @@ steps:
   - make
   - make quiettest
   - make amalgamate
+- name: checkperf
+  image: gcc:8
+  commands:
+  - make checkperf
 ---
 kind: pipeline
 name: stylecheck

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,9 @@ $(JSON_INCLUDE) $(SAJSON_INCLUDE) $(RAPIDJSON_INCLUDE) $(JSON11_INCLUDE) $(FASTJ
 parse: benchmark/parse.cpp $(HEADERS) $(LIBFILES)
 	$(CXX) $(CXXFLAGS) -o parse $(LIBFILES) benchmark/parse.cpp $(LIBFLAGS)
 
+perfdiff: benchmark/perfdiff.cpp
+	$(CXX) $(CXXFLAGS) -o perfdiff benchmark/perfdiff.cpp $(LIBFLAGS)
+
 statisticalmodel: benchmark/statisticalmodel.cpp $(HEADERS) $(LIBFILES)
 	$(CXX) $(CXXFLAGS) -o statisticalmodel $(LIBFILES) benchmark/statisticalmodel.cpp $(LIBFLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,9 @@ parse: benchmark/parse.cpp $(HEADERS) $(LIBFILES)
 perfdiff: benchmark/perfdiff.cpp
 	$(CXX) $(CXXFLAGS) -o perfdiff benchmark/perfdiff.cpp $(LIBFLAGS)
 
+checkperf:
+	bash ./scripts/checkperf.sh
+
 statisticalmodel: benchmark/statisticalmodel.cpp $(HEADERS) $(LIBFILES)
 	$(CXX) $(CXXFLAGS) -o statisticalmodel $(LIBFILES) benchmark/statisticalmodel.cpp $(LIBFLAGS)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -6,3 +6,4 @@ target_include_directories(${SIMDJSON_LIB_NAME}
 
 add_cpp_benchmark(parse)
 add_cpp_benchmark(statisticalmodel)
+add_executable(perfdiff perfdiff.cpp)

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,0 +1,25 @@
+# From the ROOT, run:
+# docker build -t simdjsonbench -f benchmark/Dockerfile . && docker run --privileged -t simdjsonbench
+FROM gcc:8.3
+
+# Build latest
+ENV latest_release=v0.2.1
+WORKDIR /usr/src/$latest_release/
+RUN git clone --depth 1 https://github.com/lemire/simdjson/ -b $latest_release .
+RUN make parse
+
+# Build master
+WORKDIR /usr/src/master/
+RUN git clone --depth 1 https://github.com/lemire/simdjson/ .
+RUN make parse
+
+# Build the current source
+COPY . /usr/src/current/
+WORKDIR /usr/src/current/
+RUN make clean
+RUN make parse
+RUN make perfdiff
+
+# Now diff them!
+ENV perftests=jsonexamples/twitter.json
+CMD echo "AGAINST master:"; ./perfdiff "/usr/src/current/parse -t "$perftests "/usr/src/master/parse -t "$perftests; echo "AGAINST "$latest_release":"; ./perfdiff "/usr/src/current/parse -t "$perftests "/usr/src/"$latest_release"/parse -t "$perftests

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -2,24 +2,18 @@
 # docker build -t simdjsonbench -f benchmark/Dockerfile . && docker run --privileged -t simdjsonbench
 FROM gcc:8.3
 
-# Build latest
-ENV latest_release=v0.2.1
-WORKDIR /usr/src/$latest_release/
-RUN git clone --depth 1 https://github.com/lemire/simdjson/ -b $latest_release .
-RUN make parse
+# # Build latest
+# ENV latest_release=v0.2.1
+# WORKDIR /usr/src/$latest_release/
+# RUN git clone --depth 1 https://github.com/lemire/simdjson/ -b $latest_release .
+# RUN make parse
 
-# Build master
-WORKDIR /usr/src/master/
-RUN git clone --depth 1 https://github.com/lemire/simdjson/ .
-RUN make parse
+# # Build master
+# WORKDIR /usr/src/master/
+# RUN git clone --depth 1 https://github.com/lemire/simdjson/ .
+# RUN make parse
 
 # Build the current source
 COPY . /usr/src/current/
 WORKDIR /usr/src/current/
-RUN make clean
-RUN make parse
-RUN make perfdiff
-
-# Now diff them!
-ENV perftests=jsonexamples/twitter.json
-CMD echo "AGAINST master:"; ./perfdiff "/usr/src/current/parse -t "$perftests "/usr/src/master/parse -t "$perftests; echo "AGAINST "$latest_release":"; ./perfdiff "/usr/src/current/parse -t "$perftests "/usr/src/"$latest_release"/parse -t "$perftests
+RUN make checkperf

--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -124,11 +124,20 @@ int main(int argc, char *argv[]) {
   bool json_output = false;
   bool force_one_iteration = false;
   bool just_data = false;
+  int32_t iterations = -1;
+  int32_t warmup_iterations = -1;
+
 #ifndef _MSC_VER
   int c;
 
-  while ((c = getopt(argc, argv, "1vdt")) != -1) {
+  while ((c = getopt(argc, argv, "1vdtn:w:")) != -1) {
     switch (c) {
+    case 'n':
+      iterations = atoi(optarg);
+      break;
+    case 'w':
+      warmup_iterations = atoi(optarg);
+      break;
     case 't':
       just_data = true;
       break;
@@ -174,12 +183,21 @@ int main(int argc, char *argv[]) {
     std::cout << "[verbose] loaded " << filename << " (" << p.size()
               << " bytes)" << std::endl;
   }
-#if defined(DEBUG)
-  const uint32_t iterations = 1;
-#else
-  const uint32_t iterations =
-      force_one_iteration ? 1 : (p.size() < 1 * 1000 * 1000 ? 1000 : 10);
-#endif
+  if (iterations == -1) {
+    #if defined(DEBUG)
+      iterations = 1;
+    #else
+      iterations = force_one_iteration ? 1 : (p.size() < 1 * 1000 * 1000 ? 1000 : 10);
+    #endif
+  }
+  if (warmup_iterations == -1) {
+    #if defined(DEBUG)
+      warmup_iterations = 0;
+    #else
+      warmup_iterations = (p.size() < 1 * 1000 * 1000) ? 10 : 1;
+    #endif
+  }
+
   std::vector<double> res;
   res.resize(iterations);
   if (!just_data)
@@ -224,9 +242,33 @@ int main(int argc, char *argv[]) {
   unsigned long cref0 = 0, cref1 = 0, cref2 = 0;
   unsigned long cmis0 = 0, cmis1 = 0, cmis2 = 0;
 #endif
+
+  // Do warmup iterations
   bool isok = true;
+  for (int32_t i = 0; i < warmup_iterations; i++) {
+    if (verbose) {
+      std::cout << "[verbose] warmup iteration # " << i << std::endl;
+    }
+    simdjson::ParsedJson pj;
+    bool allocok = pj.allocate_capacity(p.size());
+    if (!allocok) {
+      std::cerr << "failed to allocate memory" << std::endl;
+      return EXIT_FAILURE;
+    }
+    isok = (simdjson::stage1_ptr((const uint8_t *)p.data(), p.size(), pj) ==
+            simdjson::SUCCESS);
+    isok = isok &&
+           (simdjson::SUCCESS ==
+            simdjson::unified_ptr((const uint8_t *)p.data(), p.size(), pj));
+    if (!isok) {
+      std::cerr << pj.get_error_message() << std::endl;
+      std::cerr << "Could not parse. " << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
 #ifndef SQUASH_COUNTERS
-  for (uint32_t i = 0; i < iterations; i++) {
+  for (int32_t i = 0; i < iterations; i++) {
     if (verbose) {
       std::cout << "[verbose] iteration # " << i << std::endl;
     }
@@ -275,8 +317,9 @@ int main(int argc, char *argv[]) {
     }
   }
 #endif
+
   // we do it again, this time just measuring the elapsed time
-  for (uint32_t i = 0; i < iterations; i++) {
+  for (int32_t i = 0; i < iterations; i++) {
     if (verbose) {
       std::cout << "[verbose] iteration # " << i << std::endl;
     }

--- a/benchmark/perfdiff.cpp
+++ b/benchmark/perfdiff.cpp
@@ -1,0 +1,73 @@
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <sstream>
+#include <array>
+
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
+std::string exec(const char* cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) {
+        throw std::runtime_error("popen() failed!");
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+        result += buffer.data();
+    }
+    return result;
+}
+
+double readThroughput(std::string parseOutput) {
+    std::istringstream output(parseOutput);
+    std::string line;
+    double result = 0;
+    int numResults = 0;
+    while (std::getline(output, line)) {
+        int pos = 0;
+        for (int i=0; i<5; i++) {
+            pos = line.find('\t', pos);
+            if (pos < 0) {
+                std::cerr << "Command printed out a line with less than 5 fields in it:\n" << line << std::endl;
+            }
+            pos++;
+        }
+        result += std::stod(line.substr(pos));
+        numResults++;
+    }
+    return result / numResults;
+}
+
+const double ERROR_MARGIN = 10; // 10%
+const double INTERLEAVED_ATTEMPTS = 4;
+
+int main(int argc, char *argv[]) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " <new parse cmd> <reference parse cmd>";
+        return 1;
+    }
+    double newThroughput = 0;
+    double referenceThroughput = 0;
+    for (int attempt=0; attempt < INTERLEAVED_ATTEMPTS; attempt++) {
+        newThroughput += readThroughput(exec(argv[1]));
+        referenceThroughput += readThroughput(exec(argv[2]));
+    }
+    newThroughput /= INTERLEAVED_ATTEMPTS;
+    referenceThroughput /= INTERLEAVED_ATTEMPTS;
+
+    std::cout << "New throughput: " << newThroughput << std::endl;
+    std::cout << "Ref throughput: " << referenceThroughput << std::endl;
+    double percentDifference = ((newThroughput / referenceThroughput) - 1.0) * 100;
+    std::cout << "Difference: " << percentDifference << "%" << std::endl;
+    if (percentDifference < -ERROR_MARGIN) {
+        std::cerr << "New throughput is more than " << ERROR_MARGIN << "% degraded from reference throughput!" << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/scripts/checkperf.sh
+++ b/scripts/checkperf.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+# Arguments: perfdiff.sh <branch> <test json files>
+if [ -z "$1" ]; then reference_branch="master"; else reference_branch=$1; shift; fi
+if [ -z "$*" ]; then perftests="jsonexamples/twitter.json"; else perftests=$*; fi
+
+# Clone and build the reference branch's parse
+echo "Cloning and build the reference branch ($reference_branch) ..."
+current=$SCRIPTPATH/..
+reference=$current/benchbranch/$reference_branch
+rm -rf $reference
+mkdir -p $reference
+git clone --depth 1 -b $reference_branch $current/.git $reference
+cd $reference
+make parse
+
+# Build the current branch's parse
+echo "Building the current branch ..."
+cd $current
+make clean
+make parse
+
+# Run them and diff performance
+make perfdiff
+
+echo "Running perfdiff:"
+./perfdiff "$current/parse -t $perftests" "$reference/parse -t $perftests"

--- a/scripts/checkperf.sh
+++ b/scripts/checkperf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 # Arguments: perfdiff.sh <branch> <test json files>
@@ -9,16 +9,16 @@ if [ -z "$*" ]; then perftests="jsonexamples/twitter.json"; else perftests=$*; f
 
 # Clone and build the reference branch's parse
 echo "Cloning and build the reference branch ($reference_branch) ..."
-current=$SCRIPTPATH/..
 reference=$current/benchbranch/$reference_branch
 rm -rf $reference
 mkdir -p $reference
-git clone --depth 1 -b $reference_branch $current/.git $reference
+git clone --depth 1 -b $reference_branch https://github.com/lemire/simdjson $reference
 cd $reference
 make parse
 
 # Build the current branch's parse
 echo "Building the current branch ..."
+current=$SCRIPTPATH/..
 cd $current
 make clean
 make parse


### PR DESCRIPTION
This adds a performance degradation test in .drone.yml (hopefully, we'll see what happens when the PR runs :)). It checks out `master` and compares to this branch, and fails if it degrades more than 10%. Advice requested on what tolerance to use here--0% doesn't work because variance. I expect we'll also want to track it over time to make sure we don't consistently lose 1% here, 2% there until it adds up

To try to mitigate variance in performance numbers (especially in CI), I added a few things. Suggestions / feedback welcome:

* The `checkperf` is a separate step, with the hopes that we can re-run it if we believe we got a spurious result.
* We compile and measure master and current-branch performance in the same machine / container / CI run, eliminating the possibility of being assigned different hardware and strengthening the chance that the VM / container is shared with the *same* neighbor VMs / containers in the cloud (with similar workloads, one hopes).
* We build `parse.exe` for both master and current and *then* run the resulting .exes one after the other, minimizing the time between runs. Hoping that "noisy neighbors" will often be consistent enough for short periods of time that either *both* runs will be interfered with the same, or *neither* will.
* `parse.exe` runs a few "warmup" iterations where it throws away the result, to ensure the instruction caches are loaded. Not really sure what kind of difference this will make, but I've seen this done in other benchmarks, and it didn't seem wrong here :)
* `perfdiff.exe` runs the performance difference a couple of times, interleaved, and averages the results. Mainly to increase the chances that a super noisy neighbor affects both runs. Not really sure how much it impacts.