### PR TITLE
Make perf validation more stable, check no-AVX as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ jobs:
           command: make quiettest amalgamate
 
       - run:
+          name: Comparing perf against reference (gcc)
+          command: make checkperf
+
+      - run:
           name: Building (gcc, cmake, dynamic)
           command: |
             mkdir build
@@ -51,6 +55,7 @@ jobs:
           command: |
             cd buildstatic
             make test
+
       - run:
           name: Building (gcc, cmake, sanitize)
           command: |
@@ -88,6 +93,10 @@ jobs:
       - run:
           name: Running tests (gcc)
           command: ARCHFLAGS="-march=nehalem" make quiettest amalgamate
+          
+      - run:
+          name: Comparing perf against reference (gcc)
+          command: ARCHFLAGS="-march=nehalem" make checkperf
 
       - run:
           name: Building (gcc, cmake, dynamic)
@@ -155,6 +164,10 @@ jobs:
           command: make quiettest amalgamate
 
       - run:
+          name: Comparing perf against reference (clang)
+          command: make checkperf
+
+      - run:
           name: Building (clang, cmake, dynamic)
           command: |
             mkdir build
@@ -219,6 +232,10 @@ jobs:
       - run:
           name: Running tests (clang)
           command: ARCHFLAGS="-march=nehalem"  make quiettest amalgamate
+
+      - run:
+          name: Comparing perf against reference (clang)
+          command: ARCHFLAGS="-march=nehalem"  make checkperf
 
       - run:
           name: Building (clang, cmake, dynamic)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ perfdiff: benchmark/perfdiff.cpp
 	$(CXX) $(CXXFLAGS) -o perfdiff benchmark/perfdiff.cpp $(LIBFLAGS)
 
 checkperf:
-	bash ./scripts/checkperf.sh
+	bash ./scripts/checkperf.sh v0.2.1
 
 statisticalmodel: benchmark/statisticalmodel.cpp $(HEADERS) $(LIBFILES)
 	$(CXX) $(CXXFLAGS) -o statisticalmodel $(LIBFILES) benchmark/statisticalmodel.cpp $(LIBFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+REFERENCE_VERSION = v0.2.1
 
 .SUFFIXES:
 #
@@ -127,7 +128,7 @@ perfdiff: benchmark/perfdiff.cpp
 	$(CXX) $(CXXFLAGS) -o perfdiff benchmark/perfdiff.cpp $(LIBFLAGS)
 
 checkperf:
-	bash ./scripts/checkperf.sh v0.2.1
+	bash ./scripts/checkperf.sh $(REFERENCE_VERSION)
 
 statisticalmodel: benchmark/statisticalmodel.cpp $(HEADERS) $(LIBFILES)
 	$(CXX) $(CXXFLAGS) -o statisticalmodel $(LIBFILES) benchmark/statisticalmodel.cpp $(LIBFLAGS)

--- a/benchmark/perfdiff.cpp
+++ b/benchmark/perfdiff.cpp
@@ -45,25 +45,35 @@ double readThroughput(std::string parseOutput) {
 }
 
 const double INTERLEAVED_ATTEMPTS = 6;
+const double PERCENT_DIFFERENCE_THRESHOLD = -0.2;
 
 int main(int argc, char *argv[]) {
     if (argc != 3) {
-        std::cerr << "Usage: " << argv[0] << " <new parse cmd> <reference parse cmd>";
+        std::cerr << "Usage: " << argv[0] << " <new parse cmd> <reference parse cmd>" << std::endl;
         return 1;
     }
     for (int attempt=0; attempt < INTERLEAVED_ATTEMPTS; attempt++) {
+        if (attempt > 0) {
+            std::cout << "Running again to check whether it's a fluke ..." << std::endl;
+        }
         std::cout << "Attempt #" << (attempt+1) << " of up to " << INTERLEAVED_ATTEMPTS << std::endl;
+
+        // Read new throughput
         double newThroughput = readThroughput(exec(argv[1]));
         std::cout << "New throughput: " << newThroughput << std::endl;
+
+        // Read reference throughput
         double referenceThroughput = readThroughput(exec(argv[2]));
         std::cout << "Ref throughput: " << referenceThroughput << std::endl;
+
+        // Check if % difference > 0
         double percentDifference = ((newThroughput / referenceThroughput) - 1.0) * 100;
         std::cout << "Difference: " << percentDifference << "%" << std::endl;
-        if (percentDifference >= 0) {
-            std::cout << "New throughput is same or better!" << std::endl;
+        if (percentDifference >= PERCENT_DIFFERENCE_THRESHOLD) {
+            std::cout << "New throughput is same or better." << std::endl;
             return 0;
         } else {
-            std::cout << "New throughput is lower! Running again to check whether it's a fluke ...";
+            std::cout << "New throughput is lower!";
         }
     }
     return 1;

--- a/benchmark/perfdiff.cpp
+++ b/benchmark/perfdiff.cpp
@@ -44,30 +44,27 @@ double readThroughput(std::string parseOutput) {
     return result / numResults;
 }
 
-const double ERROR_MARGIN = 10; // 10%
-const double INTERLEAVED_ATTEMPTS = 4;
+const double INTERLEAVED_ATTEMPTS = 6;
 
 int main(int argc, char *argv[]) {
     if (argc != 3) {
         std::cerr << "Usage: " << argv[0] << " <new parse cmd> <reference parse cmd>";
         return 1;
     }
-    double newThroughput = 0;
-    double referenceThroughput = 0;
     for (int attempt=0; attempt < INTERLEAVED_ATTEMPTS; attempt++) {
-        newThroughput += readThroughput(exec(argv[1]));
-        referenceThroughput += readThroughput(exec(argv[2]));
+        std::cout << "Attempt #" << (attempt+1) << " of up to " << INTERLEAVED_ATTEMPTS << std::endl;
+        double newThroughput = readThroughput(exec(argv[1]));
+        std::cout << "New throughput: " << newThroughput << std::endl;
+        double referenceThroughput = readThroughput(exec(argv[2]));
+        std::cout << "Ref throughput: " << referenceThroughput << std::endl;
+        double percentDifference = ((newThroughput / referenceThroughput) - 1.0) * 100;
+        std::cout << "Difference: " << percentDifference << "%" << std::endl;
+        if (percentDifference >= 0) {
+            std::cout << "New throughput is same or better!" << std::endl;
+            return 0;
+        } else {
+            std::cout << "New throughput is lower! Running again to check whether it's a fluke ...";
+        }
     }
-    newThroughput /= INTERLEAVED_ATTEMPTS;
-    referenceThroughput /= INTERLEAVED_ATTEMPTS;
-
-    std::cout << "New throughput: " << newThroughput << std::endl;
-    std::cout << "Ref throughput: " << referenceThroughput << std::endl;
-    double percentDifference = ((newThroughput / referenceThroughput) - 1.0) * 100;
-    std::cout << "Difference: " << percentDifference << "%" << std::endl;
-    if (percentDifference < -ERROR_MARGIN) {
-        std::cerr << "New throughput is more than " << ERROR_MARGIN << "% degraded from reference throughput!" << std::endl;
-        return 1;
-    }
-    return 0;
+    return 1;
 }

--- a/scripts/checkperf.sh
+++ b/scripts/checkperf.sh
@@ -9,6 +9,7 @@ if [ -z "$*" ]; then perftests="jsonexamples/twitter.json"; else perftests=$*; f
 
 # Clone and build the reference branch's parse
 echo "Cloning and build the reference branch ($reference_branch) ..."
+current=$SCRIPTPATH/..
 reference=$current/benchbranch/$reference_branch
 rm -rf $reference
 mkdir -p $reference
@@ -18,7 +19,6 @@ make parse
 
 # Build the current branch's parse
 echo "Building the current branch ..."
-current=$SCRIPTPATH/..
 cd $current
 make clean
 make parse


### PR DESCRIPTION
Fixes the big things we wanted out of #272:
- Compare against v0.2.1 instead of master
- Do comparison up to 6 times, fail iff throughput < reference throughput all 6 times
- Check no-AVX perf as well