### PR TITLE
Lower the bar for performance check

### DIFF
--- a/benchmark/perfdiff.cpp
+++ b/benchmark/perfdiff.cpp
@@ -44,8 +44,8 @@ double readThroughput(std::string parseOutput) {
     return result / numResults;
 }
 
-const double INTERLEAVED_ATTEMPTS = 6;
-const double PERCENT_DIFFERENCE_THRESHOLD = -0.2;
+const double INTERLEAVED_ATTEMPTS = 7;
+const double PERCENT_DIFFERENCE_THRESHOLD = -0.5;
 
 int main(int argc, char *argv[]) {
     if (argc != 3) {


### PR DESCRIPTION
Since we run the performance check 8 different times in different CIs, we have to run a 7th interleaved attempt to keep the probability of false failure in the same range. I also increased the threshold to 0.5% while we were at it. False failure should be few and far between with this change, but should still reliably detect reduced performance above a certain noise level.