### PR TITLE
Use simd_input generic methods for utf8 checking

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,8 @@ steps:
   - make amalgamate
 - name: checkperf
   image: gcc:8
+  environment:
+    CHECKPERF_REPOSITORY: https://github.com/lemire/simdjson
   commands:
   - make checkperf
 ---
@@ -33,6 +35,8 @@ steps:
   - make amalgamate
 - name: checkperf
   image: gcc:8
+  environment:
+    CHECKPERF_REPOSITORY: https://github.com/lemire/simdjson
   commands:
   - make checkperf
 ---

--- a/scripts/checkperf.sh
+++ b/scripts/checkperf.sh
@@ -3,6 +3,8 @@
 set -e
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
+if [ -z "$CHECKPERF_REPOSITORY"]; then CHECKPERF_REPOSITORY=.; fi
+
 # Arguments: perfdiff.sh <branch> <test json files>
 if [ -z "$1" ]; then reference_branch="master"; else reference_branch=$1; shift; fi
 if [ -z "$*" ]; then perftests="jsonexamples/twitter.json"; else perftests=$*; fi
@@ -13,7 +15,7 @@ current=$SCRIPTPATH/..
 reference=$current/benchbranch/$reference_branch
 rm -rf $reference
 mkdir -p $reference
-git clone --depth 1 -b $reference_branch https://github.com/lemire/simdjson $reference
+git clone --depth 1 -b $reference_branch $CHECKPERF_REPOSITORY $reference
 cd $reference
 make parse
 

--- a/src/arm64/simdutf8check.h
+++ b/src/arm64/simdutf8check.h
@@ -181,7 +181,9 @@ check_utf8_bytes(int8x16_t current_bytes, struct processed_utf_bytes *previous,
 really_inline bool check_ascii_neon(simd_input<Architecture::ARM64> in) {
   // checking if the most significant bit is always equal to 0.
   uint8x16_t high_bit = vdupq_n_u8(0x80);
-  uint8x16_t any_bits_on = REDUCE_CHUNKS(in, vorrq_u8(_a, _b));
+  uint8x16_t any_bits_on = in.reduce([&](auto a, auto b) {
+    return vorrq_u8(a, b);
+  });
   uint8x16_t high_bit_on = vandq_u8(any_bits_on, high_bit);
   uint64x2_t v64 = vreinterpretq_u64_u8(high_bit_on);
   uint32x2_t v32 = vqmovn_u64(v64);

--- a/src/arm64/stage1_find_marks.h
+++ b/src/arm64/stage1_find_marks.h
@@ -39,10 +39,14 @@ really_inline void find_whitespace_and_structurals(
   });
 
   const uint8x16_t structural_shufti_mask = vmovq_n_u8(0x7);
-  structurals = MAP_BITMASK( v, vtstq_u8(_v, structural_shufti_mask) );
+  structurals = v.map([&](auto _v) {
+    return vtstq_u8(_v, structural_shufti_mask);
+  }).to_bitmask();
 
   const uint8x16_t whitespace_shufti_mask = vmovq_n_u8(0x18);
-  whitespace = MAP_BITMASK( v, vtstq_u8(_v, whitespace_shufti_mask) );
+  whitespace = v.map([&](auto _v) {
+    return vtstq_u8(_v, whitespace_shufti_mask);
+  }).to_bitmask();
 }
 
 #include "generic/stage1_find_marks_flatten.h"

--- a/src/haswell/simd_input.h
+++ b/src/haswell/simd_input.h
@@ -24,6 +24,13 @@ struct simd_input<Architecture::HASWELL> {
   }
 
   template <typename F>
+  really_inline void each(F const& each_chunk)
+  {
+    each_chunk(this->lo);
+    each_chunk(this->hi);
+  }
+
+  template <typename F>
   really_inline simd_input<Architecture::HASWELL> map(F const& map_chunk) {
     return simd_input<Architecture::HASWELL>(
       map_chunk(this->lo),
@@ -37,6 +44,11 @@ struct simd_input<Architecture::HASWELL> {
       map_chunk(this->lo, b.lo),
       map_chunk(this->hi, b.hi)
     );
+  }
+
+  template <typename F>
+  really_inline __m256i reduce(F const& reduce_pair) {
+    return reduce_pair(this->lo, this->hi);
   }
 
   really_inline uint64_t to_bitmask() {

--- a/src/haswell/simd_input.h
+++ b/src/haswell/simd_input.h
@@ -10,50 +10,51 @@ namespace simdjson {
 
 template <>
 struct simd_input<Architecture::HASWELL> {
-  __m256i lo;
-  __m256i hi;
+  __m256i chunks[2];
 
-  really_inline simd_input(const uint8_t *ptr) {
-    this->lo = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 0));
-    this->hi = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 32));
+  really_inline simd_input(const uint8_t *ptr)
+  {
+    this->chunks[0] = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 0*32));
+    this->chunks[1] = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 1*32));
   }
 
-  really_inline simd_input(__m256i a_lo, __m256i a_hi) {
-    this->lo = a_lo;
-    this->hi = a_hi;
+  really_inline simd_input(__m256i chunk0, __m256i chunk1)
+  {
+    this->chunks[0] = chunk0;
+    this->chunks[1] = chunk1;
   }
 
   template <typename F>
   really_inline void each(F const& each_chunk)
   {
-    each_chunk(this->lo);
-    each_chunk(this->hi);
+    each_chunk(this->chunks[0]);
+    each_chunk(this->chunks[1]);
   }
 
   template <typename F>
   really_inline simd_input<Architecture::HASWELL> map(F const& map_chunk) {
     return simd_input<Architecture::HASWELL>(
-      map_chunk(this->lo),
-      map_chunk(this->hi)
+      map_chunk(this->chunks[0]),
+      map_chunk(this->chunks[1])
     );
   }
 
   template <typename F>
   really_inline simd_input<Architecture::HASWELL> map(simd_input<Architecture::HASWELL> b, F const& map_chunk) {
     return simd_input<Architecture::HASWELL>(
-      map_chunk(this->lo, b.lo),
-      map_chunk(this->hi, b.hi)
+      map_chunk(this->chunks[0], b.chunks[0]),
+      map_chunk(this->chunks[1], b.chunks[1])
     );
   }
 
   template <typename F>
   really_inline __m256i reduce(F const& reduce_pair) {
-    return reduce_pair(this->lo, this->hi);
+    return reduce_pair(this->chunks[0], this->chunks[1]);
   }
 
   really_inline uint64_t to_bitmask() {
-    uint64_t r_lo = static_cast<uint32_t>(_mm256_movemask_epi8(this->lo));
-    uint64_t r_hi =                       _mm256_movemask_epi8(this->hi);
+    uint64_t r_lo = static_cast<uint32_t>(_mm256_movemask_epi8(this->chunks[0]));
+    uint64_t r_hi =                       _mm256_movemask_epi8(this->chunks[1]);
     return r_lo | (r_hi << 32);
   }
 

--- a/src/haswell/simdutf8check.h
+++ b/src/haswell/simdutf8check.h
@@ -215,7 +215,9 @@ struct utf8_checker<Architecture::HASWELL> {
 
   really_inline void check_next_input(simd_input<Architecture::HASWELL> in) {
     __m256i high_bit = _mm256_set1_epi8(0x80u);
-    __m256i any_bits_on = REDUCE_CHUNKS( in, _mm256_or_si256(_a, _b) );
+    __m256i any_bits_on = in.reduce([&](auto a, auto b) {
+      return _mm256_or_si256(a, b);
+    });
     if ((_mm256_testz_si256(any_bits_on, high_bit)) == 1) {
       // it is ascii, we just check continuation
       this->has_error = _mm256_or_si256(

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -70,7 +70,9 @@ really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
     const __m256i struct_offset = _mm256_set1_epi8(0xd4u);
     const __m256i struct_mask = _mm256_set1_epi8(32);
 
-    whitespace = MAP_BITMASK( in, _mm256_cmpeq_epi8(_in, _mm256_shuffle_epi8(white_table, _in)) );
+    whitespace = in.map([&](auto _in) {
+      return _mm256_cmpeq_epi8(_in, _mm256_shuffle_epi8(white_table, _in));
+    }).to_bitmask();
 
     structurals = in.map([&](auto _in) {
       const __m256i r1 = _mm256_add_epi8(struct_offset, _in);

--- a/src/simd_input.h
+++ b/src/simd_input.h
@@ -4,19 +4,24 @@
 #include "simdjson/common_defs.h"
 #include "simdjson/portability.h"
 #include "simdjson/simdjson.h"
-#include <cassert>
 
 namespace simdjson {
 
 template <Architecture T>
 struct simd_input {
     simd_input(const uint8_t *ptr);
+    // Run an operation on each chunk.
+    template <typename F>
+    really_inline void each(F const& each_chunk);
     // Map through each simd register in this input, producing another simd_input.
     template <typename F>
     really_inline simd_input<T> map(F const& map_chunk);
     // Map through each simd register across two inputs, producing a single simd_input.
     template <typename F>
     really_inline simd_input<T> map(simd_input<T> b, F const& map_chunk);
+    // Run a horizontal operation like "sum" across the whole input
+    // template <typename F>
+    // really_inline simd<T> reduce(F const& map_chunk);
     // turn this bytemask (usually the result of a simd comparison operation) into a bitmask.
     uint64_t to_bitmask();
     // a straightforward comparison of a mask against input.
@@ -25,10 +30,26 @@ struct simd_input {
     uint64_t lteq(uint8_t m);
 }; // struct simd_input
 
+// Transform a simd_input -> simd_input, processing each SIMD register with a SIMD -> SIMD function.
+// For example, MAP_CHUNKS(in, _mm_and_epi8(_in, _mm_set1_epi8(' ')))
 #define MAP_CHUNKS(A, EXPR) A.map([&](auto _##A) { return (EXPR); })
+// Transform a simd_input -> simd_input, processing each SIMD register with a SIMD -> SIMD function
+// and calling .to_bitmask() on the result.
+// Transform an input-sized chunk into a bitmask, processing each SIMD register and returning a SIMD
+// For example, MAP_BITMASK(in, _mm_cmpeq_epi8(_in))
 #define MAP_BITMASK(A, EXPR) MAP_CHUNKS(A, EXPR).to_bitmask()
+// Transform a pair of simd_inputs -> 1 simd_input, processing each SIMD register pair with a
+// (SIMD, SIMD) -> SIMD function.
+// For example, MAP_CHUNKS2(a, b, _mm_and_epi8(_a, _b))
 #define MAP_CHUNKS2(A, B, EXPR) A.map((B), [&](auto _##A, auto _##B) { return (EXPR); })
+// Transform a pair of simd_inputs -> bitmask, processing each SIMD register pair with a
+// (SIMD, SIMD) -> SIMD function and calling .to_bitmask() on the result.
+// For example, MAP_BITMASK2(a, b, _mm_cmpeq_epi8(_mm_and_epi8(_a, _b), _mm_set1_epi8(' ')))
 #define MAP_BITMASK2(A, B, EXPR) MAP_CHUNKS2(A, B, EXPR).to_bitmask()
+// Reduce a simd_input -> SIMD register with a (SIMD, SIMD) -> SIMD function.
+// For example, REDUCE_CHUNKS(a, b, _mm_or_epi8(_a, _b)) yields a SIMD register where each bit
+// is set if any of the bits in any of the chunk SIMD registers are set.
+#define REDUCE_CHUNKS(A, EXPR) A.reduce([&](auto _a, auto _b) { return (EXPR); })
 
 } // namespace simdjson
 

--- a/src/simd_input.h
+++ b/src/simd_input.h
@@ -30,27 +30,6 @@ struct simd_input {
     uint64_t lteq(uint8_t m);
 }; // struct simd_input
 
-// Transform a simd_input -> simd_input, processing each SIMD register with a SIMD -> SIMD function.
-// For example, MAP_CHUNKS(in, _mm_and_epi8(_in, _mm_set1_epi8(' ')))
-#define MAP_CHUNKS(A, EXPR) A.map([&](auto _##A) { return (EXPR); })
-// Transform a simd_input -> simd_input, processing each SIMD register with a SIMD -> SIMD function
-// and calling .to_bitmask() on the result.
-// Transform an input-sized chunk into a bitmask, processing each SIMD register and returning a SIMD
-// For example, MAP_BITMASK(in, _mm_cmpeq_epi8(_in))
-#define MAP_BITMASK(A, EXPR) MAP_CHUNKS(A, EXPR).to_bitmask()
-// Transform a pair of simd_inputs -> 1 simd_input, processing each SIMD register pair with a
-// (SIMD, SIMD) -> SIMD function.
-// For example, MAP_CHUNKS2(a, b, _mm_and_epi8(_a, _b))
-#define MAP_CHUNKS2(A, B, EXPR) A.map((B), [&](auto _##A, auto _##B) { return (EXPR); })
-// Transform a pair of simd_inputs -> bitmask, processing each SIMD register pair with a
-// (SIMD, SIMD) -> SIMD function and calling .to_bitmask() on the result.
-// For example, MAP_BITMASK2(a, b, _mm_cmpeq_epi8(_mm_and_epi8(_a, _b), _mm_set1_epi8(' ')))
-#define MAP_BITMASK2(A, B, EXPR) MAP_CHUNKS2(A, B, EXPR).to_bitmask()
-// Reduce a simd_input -> SIMD register with a (SIMD, SIMD) -> SIMD function.
-// For example, REDUCE_CHUNKS(a, b, _mm_or_epi8(_a, _b)) yields a SIMD register where each bit
-// is set if any of the bits in any of the chunk SIMD registers are set.
-#define REDUCE_CHUNKS(A, EXPR) A.reduce([&](auto _a, auto _b) { return (EXPR); })
-
 } // namespace simdjson
 
 #endif

--- a/src/westmere/simd_input.h
+++ b/src/westmere/simd_input.h
@@ -31,6 +31,15 @@ struct simd_input<Architecture::WESTMERE> {
   }
 
   template <typename F>
+  really_inline void each(F const& each_chunk)
+  {
+    each_chunk(this->v0);
+    each_chunk(this->v1);
+    each_chunk(this->v2);
+    each_chunk(this->v3);
+  }
+
+  template <typename F>
   really_inline simd_input<Architecture::WESTMERE> map(F const& map_chunk) {
     return simd_input<Architecture::WESTMERE>(
       map_chunk(this->v0),
@@ -48,6 +57,13 @@ struct simd_input<Architecture::WESTMERE> {
       map_chunk(this->v2, b.v2),
       map_chunk(this->v3, b.v3)
     );
+  }
+
+  template <typename F>
+  really_inline __m128i reduce(F const& reduce_pair) {
+    __m128i r01 = reduce_pair(this->v0, this->v1);
+    __m128i r23 = reduce_pair(this->v2, this->v3);
+    return reduce_pair(r01, r23);
   }
 
   really_inline uint64_t to_bitmask() {

--- a/src/westmere/simd_input.h
+++ b/src/westmere/simd_input.h
@@ -10,67 +10,64 @@ namespace simdjson {
 
 template <>
 struct simd_input<Architecture::WESTMERE> {
-  __m128i v0;
-  __m128i v1;
-  __m128i v2;
-  __m128i v3;
+  __m128i chunks[4];
 
   really_inline simd_input(const uint8_t *ptr) {
-    this->v0 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 0));
-    this->v1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 16));
-    this->v2 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 32));
-    this->v3 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 48));
+    this->chunks[0] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 0));
+    this->chunks[1] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 16));
+    this->chunks[2] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 32));
+    this->chunks[3] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 48));
   }
 
   really_inline simd_input(__m128i i0, __m128i i1, __m128i i2, __m128i i3)
   {
-    this->v0 = i0;
-    this->v1 = i1;
-    this->v2 = i2;
-    this->v3 = i3;
+    this->chunks[0] = i0;
+    this->chunks[1] = i1;
+    this->chunks[2] = i2;
+    this->chunks[3] = i3;
   }
 
   template <typename F>
   really_inline void each(F const& each_chunk)
   {
-    each_chunk(this->v0);
-    each_chunk(this->v1);
-    each_chunk(this->v2);
-    each_chunk(this->v3);
+    each_chunk(this->chunks[0]);
+    each_chunk(this->chunks[1]);
+    each_chunk(this->chunks[2]);
+    each_chunk(this->chunks[3]);
   }
 
   template <typename F>
   really_inline simd_input<Architecture::WESTMERE> map(F const& map_chunk) {
     return simd_input<Architecture::WESTMERE>(
-      map_chunk(this->v0),
-      map_chunk(this->v1),
-      map_chunk(this->v2),
-      map_chunk(this->v3)
+      map_chunk(this->chunks[0]),
+      map_chunk(this->chunks[1]),
+      map_chunk(this->chunks[2]),
+      map_chunk(this->chunks[3])
     );
   }
 
   template <typename F>
   really_inline simd_input<Architecture::WESTMERE> map(simd_input<Architecture::WESTMERE> b, F const& map_chunk) {
     return simd_input<Architecture::WESTMERE>(
-      map_chunk(this->v0, b.v0),
-      map_chunk(this->v1, b.v1),
-      map_chunk(this->v2, b.v2),
-      map_chunk(this->v3, b.v3)
+      map_chunk(this->chunks[0], b.chunks[0]),
+      map_chunk(this->chunks[1], b.chunks[1]),
+      map_chunk(this->chunks[2], b.chunks[2]),
+      map_chunk(this->chunks[3], b.chunks[3])
     );
   }
 
   template <typename F>
   really_inline __m128i reduce(F const& reduce_pair) {
-    __m128i r01 = reduce_pair(this->v0, this->v1);
-    __m128i r23 = reduce_pair(this->v2, this->v3);
+    __m128i r01 = reduce_pair(this->chunks[0], this->chunks[1]);
+    __m128i r23 = reduce_pair(this->chunks[2], this->chunks[3]);
     return reduce_pair(r01, r23);
   }
 
   really_inline uint64_t to_bitmask() {
-    uint64_t r0 = static_cast<uint32_t>(_mm_movemask_epi8(this->v0));
-    uint64_t r1 =                       _mm_movemask_epi8(this->v1);
-    uint64_t r2 =                       _mm_movemask_epi8(this->v2);
-    uint64_t r3 =                       _mm_movemask_epi8(this->v3);
+    uint64_t r0 = static_cast<uint32_t>(_mm_movemask_epi8(this->chunks[0]));
+    uint64_t r1 =                       _mm_movemask_epi8(this->chunks[1]);
+    uint64_t r2 =                       _mm_movemask_epi8(this->chunks[2]);
+    uint64_t r3 =                       _mm_movemask_epi8(this->chunks[3]);
     return r0 | (r1 << 16) | (r2 << 32) | (r3 << 48);
   }
 

--- a/src/westmere/simdutf8check.h
+++ b/src/westmere/simdutf8check.h
@@ -182,7 +182,9 @@ struct utf8_checker<Architecture::WESTMERE> {
 
   really_inline void check_next_input(simd_input<Architecture::WESTMERE> in) {
     __m128i high_bit = _mm_set1_epi8(0x80u);
-    __m128i any_bits_on = REDUCE_CHUNKS( in, _mm_or_si128(_a, _b) );
+    __m128i any_bits_on = in.reduce([&](auto a, auto b) {
+      return _mm_or_si128(a, b);
+    });
     if ((_mm_testz_si128( any_bits_on, high_bit)) == 1) {
       // it is ascii, we just check continuation
       this->has_error =

--- a/src/westmere/stage1_find_marks.h
+++ b/src/westmere/stage1_find_marks.h
@@ -28,7 +28,9 @@ really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
   const __m128i struct_offset = _mm_set1_epi8(0xd4u);
   const __m128i struct_mask = _mm_set1_epi8(32);
 
-  whitespace = MAP_BITMASK( in, _mm_cmpeq_epi8(_in, _mm_shuffle_epi8(white_table, _in)) );
+  whitespace = in.map([&](auto _in) {
+    return _mm_cmpeq_epi8(_in, _mm_shuffle_epi8(white_table, _in));
+  }).to_bitmask();
 
   structurals = in.map([&](auto _in) {
     const __m128i r1 = _mm_add_epi8(struct_offset, _in);


### PR DESCRIPTION
This is purely a draft, created so that I can see its effect on CI (and test on ARM). Given how interleaving seemed to make a difference with the equivalent stage 1 PR, I'd like to see if interleaving will speed up utf8 checking here.

Results:
- master vs. v0.2.1: 3/20 SSE failures, 0/20 AVX failures
- master vs. v0.2.1: 0/20 SSE failures, 1/20 AVX failures