### PR TITLE
Use non-interleaved map() to make structurals clearer

### DIFF
--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -72,10 +72,12 @@ really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
 
     whitespace = MAP_BITMASK( in, _mm256_cmpeq_epi8(_in, _mm256_shuffle_epi8(white_table, _in)) );
 
-    auto r1 = MAP_CHUNKS( in, _mm256_add_epi8(struct_offset, _in) );
-    auto r2 = MAP_CHUNKS( in, _mm256_or_si256(_in, struct_mask) );
-    auto r3 = MAP_CHUNKS( r1, _mm256_shuffle_epi8(structural_table, _r1) );
-    structurals = MAP_BITMASK2( r2, r3, _mm256_cmpeq_epi8(_r2, _r3) );
+    structurals = in.map([&](auto _in) {
+      const __m256i r1 = _mm256_add_epi8(struct_offset, _in);
+      const __m256i r2 = _mm256_or_si256(_in, struct_mask);
+      const __m256i r3 = _mm256_shuffle_epi8(structural_table, r1);
+      return _mm256_cmpeq_epi8(r2, r3);
+    }).to_bitmask();
 
   #endif // else SIMDJSON_NAIVE_STRUCTURAL
 }

--- a/src/westmere/stage1_find_marks.h
+++ b/src/westmere/stage1_find_marks.h
@@ -30,10 +30,12 @@ really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
 
   whitespace = MAP_BITMASK( in, _mm_cmpeq_epi8(_in, _mm_shuffle_epi8(white_table, _in)) );
 
-  auto r1 = MAP_CHUNKS( in, _mm_add_epi8(struct_offset, _in) );
-  auto r2 = MAP_CHUNKS( in, _mm_or_si128(_in, struct_mask) );
-  auto r3 = MAP_CHUNKS( r1, _mm_shuffle_epi8(structural_table, _r1) );
-  structurals = MAP_BITMASK2( r2, r3, _mm_cmpeq_epi8(_r2, _r3) );
+  structurals = in.map([&](auto _in) {
+    const __m128i r1 = _mm_add_epi8(struct_offset, _in);
+    const __m128i r2 = _mm_or_si128(_in, struct_mask);
+    const __m128i r3 = _mm_shuffle_epi8(structural_table, r1);
+    return _mm_cmpeq_epi8(r2, r3);
+  }).to_bitmask();
 }
 
 #include "generic/stage1_find_marks_flatten.h"


### PR DESCRIPTION
This is a minor change to switch the structurals calculation to do each input register separately rather than interleaving the operations, which makes the algorithm a bit easier on the eyes. At least on avx, I don't see actual perf degradation.

Apologies for the rate of PRs. It should settle down a bit now that I've figured out how to get decent perf numbers on my Windows machine. I feel a lot more confident about performance not regressing.