### PR TITLE
[WIP] Use aligned loads on AVX

### DIFF
--- a/src/arm64/simd_input.h
+++ b/src/arm64/simd_input.h
@@ -42,19 +42,16 @@ template <>
 struct simd_input<Architecture::ARM64> {
   uint8x16_t chunks[4];
 
-  really_inline simd_input(const uint8_t *ptr) {
-    this->chunks[0] = vld1q_u8(ptr + 0*16);
-    this->chunks[1] = vld1q_u8(ptr + 1*16);
-    this->chunks[2] = vld1q_u8(ptr + 2*16);
-    this->chunks[3] = vld1q_u8(ptr + 3*16);
-  }
+  really_inline simd_input(uint8x16_t chunk0, uint8x16_t chunk1, uint8x16_t chunk2, uint8x16_t chunk3)
+    : chunks{chunk0, chunk1, chunk2, chunk3 } {}
 
-  really_inline simd_input(uint8x16_t chunk0, uint8x16_t chunk1, uint8x16_t chunk2, uint8x16_t chunk3) {
-    this->chunks[0] = chunk0;
-    this->chunks[1] = chunk1;
-    this->chunks[2] = chunk2;
-    this->chunks[3] = chunk3;
-  }
+  really_inline simd_input(const uint8_t *ptr)
+      : simd_input(
+        vld1q_u8(ptr + 0*16),
+        vld1q_u8(ptr + 1*16),
+        vld1q_u8(ptr + 2*16),
+        vld1q_u8(ptr + 3*16)
+      ) {}
 
   template <typename F>
   really_inline void each(F const& each_chunk)

--- a/src/haswell/simd_input.h
+++ b/src/haswell/simd_input.h
@@ -12,17 +12,14 @@ template <>
 struct simd_input<Architecture::HASWELL> {
   __m256i chunks[2];
 
-  really_inline simd_input(const uint8_t *ptr)
-  {
-    this->chunks[0] = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 0*32));
-    this->chunks[1] = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 1*32));
-  }
-
   really_inline simd_input(__m256i chunk0, __m256i chunk1)
-  {
-    this->chunks[0] = chunk0;
-    this->chunks[1] = chunk1;
-  }
+      : chunks{chunk0, chunk1} {}
+
+  really_inline simd_input(const uint8_t *ptr)
+      : simd_input(
+        _mm256_load_si256(reinterpret_cast<const __m256i *>(ptr + 0*32)),
+        _mm256_load_si256(reinterpret_cast<const __m256i *>(ptr + 1*32))
+       ) {}
 
   template <typename F>
   really_inline void each(F const& each_chunk)

--- a/src/westmere/simd_input.h
+++ b/src/westmere/simd_input.h
@@ -12,20 +12,16 @@ template <>
 struct simd_input<Architecture::WESTMERE> {
   __m128i chunks[4];
 
-  really_inline simd_input(const uint8_t *ptr) {
-    this->chunks[0] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 0));
-    this->chunks[1] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 16));
-    this->chunks[2] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 32));
-    this->chunks[3] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 48));
-  }
+  really_inline simd_input(__m128i chunk0, __m128i chunk1, __m128i chunk2, __m128i chunk3)
+      : chunks{chunk0, chunk1, chunk2, chunk3} {}
 
-  really_inline simd_input(__m128i i0, __m128i i1, __m128i i2, __m128i i3)
-  {
-    this->chunks[0] = i0;
-    this->chunks[1] = i1;
-    this->chunks[2] = i2;
-    this->chunks[3] = i3;
-  }
+  really_inline simd_input(const uint8_t *ptr)
+      : simd_input(
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 0)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 16)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 32)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 48))
+      ) {}
 
   template <typename F>
   really_inline void each(F const& each_chunk)


### PR DESCRIPTION
This buys roughly a 1% performance improvement in overall throughput on my i7-8550U.

On AVX, with our compiler flags, `_mm256_loadu_si256` generates two instructions:

```asm
vmovdqu     xmm5, XMMWORD PTR [rdi+r12]
vinserti128 ymm1, ymm5, XMMWORD PTR [rdi+16+r12], 0x1
```

These instructions are a bottleneck on the critical path for stage 1, taking up roughly 20% of the 70-80 cycle long iteration.

They each take 6-7 cycles and are *dependent* on each other, blocking anything that uses the JSON input (which is understandably quite a lot, since this is a JSON parser) for 13 cycles. The extra instruction size (which we double because we load 2 256-bit registers) takes an extra cycle to decode, meaning it'll be another cycle before we can even try to fill the time with unrelated work.

Switching to an aligned load, `_mm256_load_si256`, generates a single instruction with half the latency:

```asm
vmovdqa ymm1, YMMWORD PTR [rdi+r12]
```

It requires that input be aligned. simdjson doesn't presently require that, IIRC. We could either change the requirement (telling people to use `realloc_if_needed`) or introduce a "pre-loop" for unaligned input that parses the first 1-3 bytes and then runs the rest of the loop on aligned memory.