### PR TITLE
Mark branches as likely/unlikely

### DIFF
--- a/src/haswell/simdutf8check.h
+++ b/src/haswell/simdutf8check.h
@@ -218,7 +218,7 @@ struct utf8_checker<Architecture::HASWELL> {
     __m256i any_bits_on = in.reduce([&](auto a, auto b) {
       return _mm256_or_si256(a, b);
     });
-    if ((_mm256_testz_si256(any_bits_on, high_bit)) == 1) {
+    if (likely(_mm256_testz_si256(any_bits_on, high_bit) == 1)) {
       // it is ascii, we just check continuation
       this->has_error = _mm256_or_si256(
           _mm256_cmpgt_epi8(this->previous.carried_continuations,

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -119,7 +119,7 @@ really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base, uint32_t idx
       base_ptr += 8;
   }
   // We hope that the next branch is easily predicted.
-  if (cnt > 8) {
+  if (unlikely(cnt > 8)) {
       base_ptr[0] = idx + trailing_zeroes(bits);
       bits = _blsr_u64(bits);
       base_ptr[1] = idx + trailing_zeroes(bits);
@@ -138,9 +138,10 @@ really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base, uint32_t idx
       bits = _blsr_u64(bits);
       base_ptr += 8;
   }
-  if (cnt > 16) { // unluckly: we rarely get here
+  if (unlikely(cnt > 16)) { // unluckly: we rarely get here
       // since it means having one structural or pseudo-structral element
-      // every 4 characters (possible with inputs like "","","",...).
+      // every 4 characters (the max possible is an array of integers: [1,2,3,4,5,6...] will have
+      // 64 elements in 64 bytes).
       do {
       base_ptr[0] = idx + trailing_zeroes(bits);
       bits = _blsr_u64(bits);


### PR DESCRIPTION
Marking branches with our expectations has a marked (1% overall throughput) improvement on performance on my i7-8550U, across many files.

Marking the utf-8 check and the flatten_bits checks in particular, I see the 1% gain across the board for AVX-2 (this includes low-branch-misprediction files like `canada.json` and `random.json`, and high branch-misprediction files like `twitter.json` and `mesh.json`)

The `if (unlikely(cnt > 8))` check was the one I was least sure about, and when done all by itself, it does have a substantial impact on many files but had a tiny degradation on `canada.json` (less than 0.5%, low enough that I can't be sure it's not noise). The other if checks clearly made up for it in most cases.

I went ahead and stuck `unlikely` on all the error cases, even if they were once per iteration, but I don't know if that will have any performance impact anywhere ...

The stage 1 throughput improvement numbers:

* likely(ascii): 7% mesh, 3.5% twitter
* unlikely(cnt > 8): 1.5% mesh, 3% twitter
* unlikely(cnt > 16): 1.5% mesh, 1% twitter
* all three together: 7.5% mesh, 5% twitter