### PR TITLE
Combined performance patch (5% overall, 15% stage 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /jsoncheck
 /jsonpointer
 /jsonstats
+/integer_tests
 /libsimdjson.so*
 /minify
 /numberparsingcheck

--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -36,7 +36,15 @@
 #include "simdjson/stage2_build_tape.h"
 
 // Global arguments
-static bool find_marks_only = false;
+bool find_marks_only = false;
+bool verbose = false;
+bool dump = false;
+bool json_output = false;
+bool force_one_iteration = false;
+bool just_data = false;
+bool force_sse = false;
+int32_t iterations = -1;
+int32_t warmup_iterations = -1;
 
 namespace simdjson {
 Architecture _find_best_supported_implementation() {
@@ -47,7 +55,7 @@ Architecture _find_best_supported_implementation() {
       instruction_set::SSE42 | instruction_set::PCLMULQDQ;
   uint32_t supports = detect_supported_architectures();
   // Order from best to worst (within architecture)
-  if ((haswell_flags & supports) == haswell_flags) {
+  if ((haswell_flags & supports) == haswell_flags && !force_sse) {
     return Architecture::HASWELL;
   }
   if ((westmere_flags & supports) == westmere_flags) {
@@ -125,24 +133,20 @@ unified_functype *unified_ptr = &unified_machine_dispatch;
 } // namespace simdjson
 
 int main(int argc, char *argv[]) {
-  bool verbose = false;
-  bool dump = false;
-  bool json_output = false;
-  bool force_one_iteration = false;
-  bool just_data = false;
-  int32_t iterations = -1;
-  int32_t warmup_iterations = -1;
 
 #ifndef _MSC_VER
   int c;
 
-  while ((c = getopt(argc, argv, "1vdtn:w:f")) != -1) {
+  while ((c = getopt(argc, argv, "1vdtn:w:fs")) != -1) {
     switch (c) {
     case 'n':
       iterations = atoi(optarg);
       break;
     case 'w':
       warmup_iterations = atoi(optarg);
+      break;
+    case 's':
+      force_sse = true;
       break;
     case 't':
       just_data = true;

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -17,6 +17,17 @@
 #define SIMDJSON_PADDING 32
 #endif
 
+#if defined(__GNUC__)
+// Marks a block with a name so that MCA analysis can see it.
+#define BEGIN_DEBUG_BLOCK(name) __asm volatile("# LLVM-MCA-BEGIN " #name);
+#define END_DEBUG_BLOCK(name) __asm volatile("# LLVM-MCA-END " #name);
+#define DEBUG_BLOCK(name, block) BEGIN_DEBUG_BLOCK(name); block; END_DEBUG_BLOCK(name);
+#else
+#define BEGIN_DEBUG_BLOCK(name)
+#define END_DEBUG_BLOCK(name)
+#define DEBUG_BLOCK(name, block)
+#endif
+
 #ifndef _MSC_VER
 // Implemented using Labels as Values which works in GCC and CLANG (and maybe
 // also in Intel's compiler), but won't work in MSVC.

--- a/scripts/checkperf.sh
+++ b/scripts/checkperf.sh
@@ -29,5 +29,5 @@ make parse
 make perfdiff
 
 echo "Running perfdiff:"
-echo ./perfdiff \"$current/parse -t $perftests\" \"$reference/parse -t $perftests\"
-./perfdiff "$current/parse -t $perftests" "$reference/parse -t $perftests"
+echo ./perfdiff \"$current/parse -t $perftests $CHECKPERF_ARGS\" \"$reference/parse -t $perftests $CHECKPERF_ARGS\"
+./perfdiff "$current/parse -t $perftests $CHECKPERF_ARGS" "$reference/parse -t $perftests $CHECKPERF_ARGS"

--- a/src/arm64/simd_input.h
+++ b/src/arm64/simd_input.h
@@ -40,21 +40,21 @@ using namespace simdjson::arm64;
 
 template <>
 struct simd_input<Architecture::ARM64> {
-  uint8x16_t chunks[4];
+  const uint8x16_t chunks[4];
 
-  really_inline simd_input(const uint8_t *ptr) {
-    this->chunks[0] = vld1q_u8(ptr + 0*16);
-    this->chunks[1] = vld1q_u8(ptr + 1*16);
-    this->chunks[2] = vld1q_u8(ptr + 2*16);
-    this->chunks[3] = vld1q_u8(ptr + 3*16);
-  }
+  really_inline simd_input()
+    : chunks{uint8x16_t(), uint8x16_t(), uint8x16_t(), uint8x16_t() } {}
 
-  really_inline simd_input(uint8x16_t chunk0, uint8x16_t chunk1, uint8x16_t chunk2, uint8x16_t chunk3) {
-    this->chunks[0] = chunk0;
-    this->chunks[1] = chunk1;
-    this->chunks[2] = chunk2;
-    this->chunks[3] = chunk3;
-  }
+  really_inline simd_input(const uint8x16_t chunk0, const uint8x16_t chunk1, const uint8x16_t chunk2, const uint8x16_t chunk3)
+    : chunks{chunk0, chunk1, chunk2, chunk3 } {}
+
+  really_inline simd_input(const uint8_t *ptr)
+      : chunks{
+        vld1q_u8(ptr + 0*16),
+        vld1q_u8(ptr + 1*16),
+        vld1q_u8(ptr + 2*16),
+        vld1q_u8(ptr + 3*16)
+       } {}
 
   template <typename F>
   really_inline void each(F const& each_chunk) const {

--- a/src/arm64/stage1_find_marks.h
+++ b/src/arm64/stage1_find_marks.h
@@ -12,7 +12,7 @@
 
 namespace simdjson::arm64 {
 
-really_inline uint64_t compute_quote_mask(uint64_t quote_bits) {
+really_inline uint64_t compute_quote_mask(const uint64_t quote_bits) {
 
 #ifdef __ARM_FEATURE_CRYPTO // some ARM processors lack this extension
   return vmull_p64(-1ULL, quote_bits);
@@ -21,9 +21,9 @@ really_inline uint64_t compute_quote_mask(uint64_t quote_bits) {
 #endif
 }
 
-really_inline void find_whitespace_and_structurals(
-    simd_input<ARCHITECTURE> in, uint64_t &whitespace,
-    uint64_t &structurals) {
+really_inline void find_whitespace_and_operators(
+    const simd_input<ARCHITECTURE> in,
+    uint64_t &whitespace, uint64_t &op) {
   const uint8x16_t low_nibble_mask =
       (uint8x16_t){16, 0, 0, 0, 0, 0, 0, 0, 0, 8, 12, 1, 2, 9, 0, 0};
   const uint8x16_t high_nibble_mask =
@@ -38,9 +38,9 @@ really_inline void find_whitespace_and_structurals(
     return vandq_u8(shuf_lo, shuf_hi);
   });
 
-  const uint8x16_t structural_shufti_mask = vmovq_n_u8(0x7);
-  structurals = v.map([&](auto _v) {
-    return vtstq_u8(_v, structural_shufti_mask);
+  const uint8x16_t operator_shufti_mask = vmovq_n_u8(0x7);
+  op = v.map([&](auto _v) {
+    return vtstq_u8(_v, operator_shufti_mask);
   }).to_bitmask();
 
   const uint8x16_t whitespace_shufti_mask = vmovq_n_u8(0x18);

--- a/src/generic/stage1_find_marks_flatten.h
+++ b/src/generic/stage1_find_marks_flatten.h
@@ -26,16 +26,14 @@ really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base, uint32_t idx
 // base_ptr[base] incrementing base as we go
 // will potentially store extra values beyond end of valid bits, so base_ptr
 // needs to be large enough to handle this
-really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base, uint32_t idx, uint64_t bits) {
+really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits) {
   // In some instances, the next branch is expensive because it is mispredicted.
   // Unfortunately, in other cases,
   // it helps tremendously.
   if (bits == 0)
     return;
   uint32_t cnt = hamming(bits);
-  uint32_t next_base = base + cnt;
   idx -= 64;
-  base_ptr += base;
   {
     base_ptr[0] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
@@ -53,37 +51,36 @@ really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base, uint32_t idx
     bits = bits & (bits - 1);
     base_ptr[7] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr += 8;
   }
   // We hope that the next branch is easily predicted.
   if (cnt > 8) {
-    base_ptr[0] = idx + trailing_zeroes(bits);
+    base_ptr[8] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[1] = idx + trailing_zeroes(bits);
+    base_ptr[9] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[2] = idx + trailing_zeroes(bits);
+    base_ptr[10] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[3] = idx + trailing_zeroes(bits);
+    base_ptr[11] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[4] = idx + trailing_zeroes(bits);
+    base_ptr[12] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[5] = idx + trailing_zeroes(bits);
+    base_ptr[13] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[6] = idx + trailing_zeroes(bits);
+    base_ptr[14] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr[7] = idx + trailing_zeroes(bits);
+    base_ptr[15] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
-    base_ptr += 8;
   }
   if (cnt > 16) { // unluckly: we rarely get here
     // since it means having one structural or pseudo-structral element
     // every 4 characters (possible with inputs like "","","",...).
+    uint32_t i = 16;
     do {
-      base_ptr[0] = idx + trailing_zeroes(bits);
+      base_ptr[i] = idx + trailing_zeroes(bits);
       bits = bits & (bits - 1);
-      base_ptr++;
-    } while (bits != 0);
+      i++;
+    } while (i < cnt);
   }
-  base = next_base;
+  base_ptr += cnt;
 }
 #endif // SIMDJSON_NAIVE_FLATTEN

--- a/src/generic/stage1_find_marks_flatten.h
+++ b/src/generic/stage1_find_marks_flatten.h
@@ -34,46 +34,26 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
     return;
   uint32_t cnt = hamming(bits);
   idx -= 64;
-  {
-    base_ptr[0] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[1] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[2] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[3] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[4] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[5] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[6] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[7] = idx + trailing_zeroes(bits);
+
+  // Do the first 8 all together
+  for (int i=0; i<8; i++) {
+    base_ptr[i] = idx + trailing_zeroes(bits);
     bits = bits & (bits - 1);
   }
-  // We hope that the next branch is easily predicted.
+
+  // Do the next 8 all together (we hope in most cases it won't happen at all
+  // and the branch is easily predicted).
   if (cnt > 8) {
-    base_ptr[8] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[9] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[10] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[11] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[12] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[13] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[14] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
-    base_ptr[15] = idx + trailing_zeroes(bits);
-    bits = bits & (bits - 1);
+    for (int i=8; i<16; i++) {
+      base_ptr[i] = idx + trailing_zeroes(bits);
+      bits = bits & (bits - 1);
+    }
   }
-  if (cnt > 16) { // unluckly: we rarely get here
-    // since it means having one structural or pseudo-structral element
-    // every 4 characters (possible with inputs like "","","",...).
+
+  // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+  // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+  // or the start of a value ("abc" true 123) every 4 characters.
+  if (cnt > 16) {
     uint32_t i = 16;
     do {
       base_ptr[i] = idx + trailing_zeroes(bits);

--- a/src/generic/stage1_find_marks_flatten.h
+++ b/src/generic/stage1_find_marks_flatten.h
@@ -43,7 +43,7 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
 
   // Do the next 8 all together (we hope in most cases it won't happen at all
   // and the branch is easily predicted).
-  if (cnt > 8) {
+  if (unlikely(cnt > 8)) {
     for (int i=8; i<16; i++) {
       base_ptr[i] = idx + trailing_zeroes(bits);
       bits = bits & (bits - 1);
@@ -53,7 +53,7 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
   // Most files don't have 16+ structurals per block, so we take several basically guaranteed
   // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
   // or the start of a value ("abc" true 123) every 4 characters.
-  if (cnt > 16) {
+  if (unlikely(cnt > 16)) {
     uint32_t i = 16;
     do {
       base_ptr[i] = idx + trailing_zeroes(bits);
@@ -61,6 +61,7 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
       i++;
     } while (i < cnt);
   }
+
   base_ptr += cnt;
 }
 #endif // SIMDJSON_NAIVE_FLATTEN

--- a/src/generic/stage1_find_marks_flatten.h
+++ b/src/generic/stage1_find_marks_flatten.h
@@ -48,18 +48,18 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
       base_ptr[i] = idx + trailing_zeroes(bits);
       bits = bits & (bits - 1);
     }
-  }
 
-  // Most files don't have 16+ structurals per block, so we take several basically guaranteed
-  // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
-  // or the start of a value ("abc" true 123) every 4 characters.
-  if (unlikely(cnt > 16)) {
-    uint32_t i = 16;
-    do {
-      base_ptr[i] = idx + trailing_zeroes(bits);
-      bits = bits & (bits - 1);
-      i++;
-    } while (i < cnt);
+    // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+    // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+    // or the start of a value ("abc" true 123) every 4 characters.
+    if (unlikely(cnt > 16)) {
+      uint32_t i = 16;
+      do {
+        base_ptr[i] = idx + trailing_zeroes(bits);
+        bits = bits & (bits - 1);
+        i++;
+      } while (i < cnt);
+    }
   }
 
   base_ptr += cnt;

--- a/src/haswell/simd_input.h
+++ b/src/haswell/simd_input.h
@@ -18,21 +18,21 @@ struct simd_input<Architecture::HASWELL> {
     this->chunks[1] = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 1*32));
   }
 
-  really_inline simd_input(__m256i chunk0, __m256i chunk1)
+  really_inline simd_input(const __m256i chunk0, const __m256i chunk1)
   {
     this->chunks[0] = chunk0;
     this->chunks[1] = chunk1;
   }
 
   template <typename F>
-  really_inline void each(F const& each_chunk)
+  really_inline void each(F const& each_chunk) const
   {
     each_chunk(this->chunks[0]);
     each_chunk(this->chunks[1]);
   }
 
   template <typename F>
-  really_inline simd_input<Architecture::HASWELL> map(F const& map_chunk) {
+  really_inline simd_input<Architecture::HASWELL> map(F const& map_chunk) const {
     return simd_input<Architecture::HASWELL>(
       map_chunk(this->chunks[0]),
       map_chunk(this->chunks[1])
@@ -40,7 +40,7 @@ struct simd_input<Architecture::HASWELL> {
   }
 
   template <typename F>
-  really_inline simd_input<Architecture::HASWELL> map(simd_input<Architecture::HASWELL> b, F const& map_chunk) {
+  really_inline simd_input<Architecture::HASWELL> map(const simd_input<Architecture::HASWELL> b, F const& map_chunk) const {
     return simd_input<Architecture::HASWELL>(
       map_chunk(this->chunks[0], b.chunks[0]),
       map_chunk(this->chunks[1], b.chunks[1])
@@ -48,24 +48,31 @@ struct simd_input<Architecture::HASWELL> {
   }
 
   template <typename F>
-  really_inline __m256i reduce(F const& reduce_pair) {
+  really_inline __m256i reduce(F const& reduce_pair) const {
     return reduce_pair(this->chunks[0], this->chunks[1]);
   }
 
-  really_inline uint64_t to_bitmask() {
+  really_inline uint64_t to_bitmask() const {
     uint64_t r_lo = static_cast<uint32_t>(_mm256_movemask_epi8(this->chunks[0]));
     uint64_t r_hi =                       _mm256_movemask_epi8(this->chunks[1]);
     return r_lo | (r_hi << 32);
   }
 
-  really_inline uint64_t eq(uint8_t m) {
+  really_inline simd_input<Architecture::HASWELL> bit_or(const uint8_t m) const {
+    const __m256i mask = _mm256_set1_epi8(m);
+    return this->map( [&](auto a) {
+      return _mm256_or_si256(a, mask);
+    });
+  }
+
+  really_inline uint64_t eq(const uint8_t m) const {
     const __m256i mask = _mm256_set1_epi8(m);
     return this->map( [&](auto a) {
       return _mm256_cmpeq_epi8(a, mask);
     }).to_bitmask();
   }
 
-  really_inline uint64_t lteq(uint8_t m) {
+  really_inline uint64_t lteq(const uint8_t m) const {
     const __m256i maxval = _mm256_set1_epi8(m);
     return this->map( [&](auto a) {
       return _mm256_cmpeq_epi8(_mm256_max_epu8(maxval, a), maxval);

--- a/src/haswell/simd_input.h
+++ b/src/haswell/simd_input.h
@@ -10,19 +10,18 @@ namespace simdjson {
 
 template <>
 struct simd_input<Architecture::HASWELL> {
-  __m256i chunks[2];
+  const __m256i chunks[2];
 
-  really_inline simd_input(const uint8_t *ptr)
-  {
-    this->chunks[0] = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 0*32));
-    this->chunks[1] = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 1*32));
-  }
+  really_inline simd_input() : chunks{__m256i(), __m256i()} {}
 
   really_inline simd_input(const __m256i chunk0, const __m256i chunk1)
-  {
-    this->chunks[0] = chunk0;
-    this->chunks[1] = chunk1;
-  }
+      : chunks{chunk0, chunk1} {}
+
+  really_inline simd_input(const uint8_t *ptr)
+      : chunks{
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 0*32)),
+        _mm256_loadu_si256(reinterpret_cast<const __m256i *>(ptr + 1*32))
+      } {}
 
   template <typename F>
   really_inline void each(F const& each_chunk) const

--- a/src/haswell/simdutf8check.h
+++ b/src/haswell/simdutf8check.h
@@ -218,7 +218,7 @@ struct utf8_checker<Architecture::HASWELL> {
     __m256i any_bits_on = in.reduce([&](auto a, auto b) {
       return _mm256_or_si256(a, b);
     });
-    if ((_mm256_testz_si256(any_bits_on, high_bit)) == 1) {
+    if (likely(_mm256_testz_si256(any_bits_on, high_bit) == 1)) {
       // it is ascii, we just check continuation
       this->has_error = _mm256_or_si256(
           _mm256_cmpgt_epi8(this->previous.carried_continuations,

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -97,47 +97,26 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
       return;
   uint32_t cnt = _mm_popcnt_u64(bits);
   idx -= 64;
-  {
-    base_ptr[0] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[1] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[2] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[3] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[4] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[5] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[6] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[7] = idx + trailing_zeroes(bits);
+
+  // Do the first 8 all together
+  for (int i=0; i<8; i++) {
+    base_ptr[i] = idx + trailing_zeroes(bits);
     bits = _blsr_u64(bits);
   }
-  // We hope that the next branch is easily predicted.
+
+  // Do the next 8 all together (we hope in most cases it won't happen at all
+  // and the branch is easily predicted).
   if (cnt > 8) {
-    base_ptr[8] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[9] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[10] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[11] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[12] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[13] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[14] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
-    base_ptr[15] = idx + trailing_zeroes(bits);
-    bits = _blsr_u64(bits);
+    for (int i=8; i<16; i++) {
+      base_ptr[i] = idx + trailing_zeroes(bits);
+      bits = _blsr_u64(bits);
+    }
   }
+
+  // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+  // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+  // or the start of a value ("abc" true 123) every four characters.
   if (cnt > 16) {
-    // unluckly: this loop will rarely ever trigger
-    // since it means having one structural or pseudo-structral element
-    // every 4 characters (possible with inputs like "","","",...).
     uint32_t i = 16;
     do {
       base_ptr[i] = idx + trailing_zeroes(bits);

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -112,18 +112,18 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
       base_ptr[i] = idx + trailing_zeroes(bits);
       bits = _blsr_u64(bits);
     }
-  }
 
-  // Most files don't have 16+ structurals per block, so we take several basically guaranteed
-  // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
-  // or the start of a value ("abc" true 123) every four characters.
-  if (unlikely(cnt > 16)) {
-    uint32_t i = 16;
-    do {
-      base_ptr[i] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      i++;
-    } while (i < cnt);
+    // Most files don't have 16+ structurals per block, so we take several basically guaranteed
+    // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
+    // or the start of a value ("abc" true 123) every four characters.
+    if (unlikely(cnt > 16)) {
+      uint32_t i = 16;
+      do {
+        base_ptr[i] = idx + trailing_zeroes(bits);
+        bits = _blsr_u64(bits);
+        i++;
+      } while (i < cnt);
+    }
   }
 
   base_ptr += cnt;

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -107,7 +107,7 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
 
   // Do the next 8 all together (we hope in most cases it won't happen at all
   // and the branch is easily predicted).
-  if (cnt > 8) {
+  if (unlikely(cnt > 8)) {
     for (int i=8; i<16; i++) {
       base_ptr[i] = idx + trailing_zeroes(bits);
       bits = _blsr_u64(bits);
@@ -117,7 +117,7 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
   // Most files don't have 16+ structurals per block, so we take several basically guaranteed
   // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
   // or the start of a value ("abc" true 123) every four characters.
-  if (cnt > 16) {
+  if (unlikely(cnt > 16)) {
     uint32_t i = 16;
     do {
       base_ptr[i] = idx + trailing_zeroes(bits);
@@ -125,6 +125,7 @@ really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits
       i++;
     } while (i < cnt);
   }
+
   base_ptr += cnt;
 }
 

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -13,7 +13,7 @@
 TARGET_HASWELL
 namespace simdjson::haswell {
 
-really_inline uint64_t compute_quote_mask(uint64_t quote_bits) {
+really_inline uint64_t compute_quote_mask(const uint64_t quote_bits) {
   // There should be no such thing with a processing supporting avx2
   // but not clmul.
   uint64_t quote_mask = _mm_cvtsi128_si64(_mm_clmulepi64_si128(
@@ -21,8 +21,9 @@ really_inline uint64_t compute_quote_mask(uint64_t quote_bits) {
   return quote_mask;
 }
 
-really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
-  uint64_t &whitespace, uint64_t &structurals) {
+really_inline void find_whitespace_and_operators(
+  const simd_input<ARCHITECTURE> in,
+  uint64_t &whitespace, uint64_t &op) {
 
   #ifdef SIMDJSON_NAIVE_STRUCTURAL
 
@@ -34,14 +35,14 @@ really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
     const __m256i mask_close_bracket = _mm256_set1_epi8(0x5d);
     const __m256i mask_column = _mm256_set1_epi8(0x3a);
     const __m256i mask_comma = _mm256_set1_epi8(0x2c);
-    structurals = in.map([&](auto in) {
-      __m256i structurals = _mm256_cmpeq_epi8(in, mask_open_brace);
-      structurals = _mm256_or_si256(structurals, _mm256_cmpeq_epi8(in, mask_close_brace));
-      structurals = _mm256_or_si256(structurals, _mm256_cmpeq_epi8(in, mask_open_bracket));
-      structurals = _mm256_or_si256(structurals, _mm256_cmpeq_epi8(in, mask_close_bracket));
-      structurals = _mm256_or_si256(structurals, _mm256_cmpeq_epi8(in, mask_column));
-      structurals = _mm256_or_si256(structurals, _mm256_cmpeq_epi8(in, mask_comma));
-      return structurals;
+    op = in.map([&](auto in) {
+      __m256i op = _mm256_cmpeq_epi8(in, mask_open_brace);
+      op = _mm256_or_si256(op, _mm256_cmpeq_epi8(in, mask_close_brace));
+      op = _mm256_or_si256(op, _mm256_cmpeq_epi8(in, mask_open_bracket));
+      op = _mm256_or_si256(op, _mm256_cmpeq_epi8(in, mask_close_bracket));
+      op = _mm256_or_si256(op, _mm256_cmpeq_epi8(in, mask_column));
+      op = _mm256_or_si256(op, _mm256_cmpeq_epi8(in, mask_comma));
+      return op;
     }).to_bitmask();
 
     const __m256i mask_space = _mm256_set1_epi8(0x20);
@@ -60,24 +61,24 @@ really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
   #else  // SIMDJSON_NAIVE_STRUCTURAL
 
     // clang-format off
-    const __m256i structural_table =
+    const __m256i operator_table =
         _mm256_setr_epi8(44, 125, 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123,
                          44, 125, 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123);
     const __m256i white_table = _mm256_setr_epi8(
         32, 100, 100, 100, 17, 100, 113, 2, 100, 9, 10, 112, 100, 13, 100, 100,
         32, 100, 100, 100, 17, 100, 113, 2, 100, 9, 10, 112, 100, 13, 100, 100);
     // clang-format on
-    const __m256i struct_offset = _mm256_set1_epi8(0xd4u);
-    const __m256i struct_mask = _mm256_set1_epi8(32);
+    const __m256i op_offset = _mm256_set1_epi8(0xd4u);
+    const __m256i op_mask = _mm256_set1_epi8(32);
 
     whitespace = in.map([&](auto _in) {
       return _mm256_cmpeq_epi8(_in, _mm256_shuffle_epi8(white_table, _in));
     }).to_bitmask();
 
-    structurals = in.map([&](auto _in) {
-      const __m256i r1 = _mm256_add_epi8(struct_offset, _in);
-      const __m256i r2 = _mm256_or_si256(_in, struct_mask);
-      const __m256i r3 = _mm256_shuffle_epi8(structural_table, r1);
+    op = in.map([&](auto _in) {
+      const __m256i r1 = _mm256_add_epi8(op_offset, _in);
+      const __m256i r2 = _mm256_or_si256(_in, op_mask);
+      const __m256i r3 = _mm256_shuffle_epi8(operator_table, r1);
       return _mm256_cmpeq_epi8(r2, r3);
     }).to_bitmask();
 

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -89,65 +89,63 @@ really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
 // base_ptr[base] incrementing base as we go
 // will potentially store extra values beyond end of valid bits, so base_ptr
 // needs to be large enough to handle this
-really_inline void flatten_bits(uint32_t *base_ptr, uint32_t &base, uint32_t idx, uint64_t bits) {
+really_inline void flatten_bits(uint32_t *&base_ptr, uint32_t idx, uint64_t bits) {
   // In some instances, the next branch is expensive because it is mispredicted.
   // Unfortunately, in other cases,
   // it helps tremendously.
   if (bits == 0)
       return;
   uint32_t cnt = _mm_popcnt_u64(bits);
-  uint32_t next_base = base + cnt;
   idx -= 64;
-  base_ptr += base;
   {
-      base_ptr[0] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[1] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[2] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[3] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[4] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[5] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[6] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[7] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr += 8;
+    base_ptr[0] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[1] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[2] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[3] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[4] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[5] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[6] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[7] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
   }
   // We hope that the next branch is easily predicted.
   if (cnt > 8) {
-      base_ptr[0] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[1] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[2] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[3] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[4] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[5] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[6] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr[7] = idx + trailing_zeroes(bits);
-      bits = _blsr_u64(bits);
-      base_ptr += 8;
+    base_ptr[8] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[9] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[10] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[11] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[12] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[13] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[14] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
+    base_ptr[15] = idx + trailing_zeroes(bits);
+    bits = _blsr_u64(bits);
   }
-  if (cnt > 16) { // unluckly: we rarely get here
-      // since it means having one structural or pseudo-structral element
-      // every 4 characters (possible with inputs like "","","",...).
-      do {
-      base_ptr[0] = idx + trailing_zeroes(bits);
+  if (cnt > 16) {
+    // unluckly: this loop will rarely ever trigger
+    // since it means having one structural or pseudo-structral element
+    // every 4 characters (possible with inputs like "","","",...).
+    uint32_t i = 16;
+    do {
+      base_ptr[i] = idx + trailing_zeroes(bits);
       bits = _blsr_u64(bits);
-      base_ptr++;
-      } while (bits != 0);
+      i++;
+    } while (i < cnt);
   }
-  base = next_base;
+  base_ptr += cnt;
 }
 
 #include "generic/stage1_find_marks.h"

--- a/src/westmere/simd_input.h
+++ b/src/westmere/simd_input.h
@@ -10,22 +10,21 @@ namespace simdjson {
 
 template <>
 struct simd_input<Architecture::WESTMERE> {
-  __m128i chunks[4];
+  const __m128i chunks[4];
 
-  really_inline simd_input(const uint8_t *ptr) {
-    this->chunks[0] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 0));
-    this->chunks[1] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 16));
-    this->chunks[2] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 32));
-    this->chunks[3] = _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 48));
-  }
+  really_inline simd_input()
+      : chunks { __m128i(), __m128i(), __m128i(), __m128i() } {}
 
-  really_inline simd_input(__m128i i0, __m128i i1, __m128i i2, __m128i i3)
-  {
-    this->chunks[0] = i0;
-    this->chunks[1] = i1;
-    this->chunks[2] = i2;
-    this->chunks[3] = i3;
-  }
+  really_inline simd_input(const __m128i chunk0, const __m128i chunk1, const __m128i chunk2, const __m128i chunk3)
+      : chunks{chunk0, chunk1, chunk2, chunk3} {}
+
+  really_inline simd_input(const uint8_t *ptr)
+      : simd_input(
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 0)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 16)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 32)),
+        _mm_loadu_si128(reinterpret_cast<const __m128i *>(ptr + 48))
+      ) {}
 
   template <typename F>
   really_inline void each(F const& each_chunk) const {

--- a/src/westmere/stage1_find_marks.h
+++ b/src/westmere/stage1_find_marks.h
@@ -13,29 +13,30 @@
 TARGET_WESTMERE
 namespace simdjson::westmere {
 
-really_inline uint64_t compute_quote_mask(uint64_t quote_bits) {
+really_inline uint64_t compute_quote_mask(const uint64_t quote_bits) {
   return _mm_cvtsi128_si64(_mm_clmulepi64_si128(
       _mm_set_epi64x(0ULL, quote_bits), _mm_set1_epi8(0xFFu), 0));
 }
 
-really_inline void find_whitespace_and_structurals(simd_input<ARCHITECTURE> in,
-  uint64_t &whitespace, uint64_t &structurals) {
+really_inline void find_whitespace_and_operators(
+  const simd_input<ARCHITECTURE> in,
+  uint64_t &whitespace, uint64_t &op) {
 
-  const __m128i structural_table =
+  const __m128i operator_table =
       _mm_setr_epi8(44, 125, 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 123);
   const __m128i white_table = _mm_setr_epi8(32, 100, 100, 100,  17, 100, 113,   2,
                                            100,   9,  10, 112, 100,  13, 100, 100);
-  const __m128i struct_offset = _mm_set1_epi8(0xd4u);
-  const __m128i struct_mask = _mm_set1_epi8(32);
+  const __m128i op_offset = _mm_set1_epi8(0xd4u);
+  const __m128i op_mask = _mm_set1_epi8(32);
 
   whitespace = in.map([&](auto _in) {
     return _mm_cmpeq_epi8(_in, _mm_shuffle_epi8(white_table, _in));
   }).to_bitmask();
 
-  structurals = in.map([&](auto _in) {
-    const __m128i r1 = _mm_add_epi8(struct_offset, _in);
-    const __m128i r2 = _mm_or_si128(_in, struct_mask);
-    const __m128i r3 = _mm_shuffle_epi8(structural_table, r1);
+  op = in.map([&](auto _in) {
+    const __m128i r1 = _mm_add_epi8(op_offset, _in);
+    const __m128i r2 = _mm_or_si128(_in, op_mask);
+    const __m128i r3 = _mm_shuffle_epi8(operator_table, r1);
     return _mm_cmpeq_epi8(r2, r3);
   }).to_bitmask();
 }


### PR DESCRIPTION
This brings together all of the performance patches except [aligned loads](https://github.com/lemire/simdjson/pull/315), and even does the loop unrolling a little better (interleaving the two iterations for another 1-2% boost or so). All performance impacts are understood (at least, I have a story that purports to explain them :)) and the reordering in particular is explained in code comments.

Across all files (see [comment below](https://github.com/lemire/simdjson/pull/317#issuecomment-534256380)), it gives a 5% overall throughput improvement on average on my AVX2 Kady Lake R processor, or 1-9% improvement depending largely on the density of json elements in the file. Stage 1's improvement is 11-20%, averaging around 15%. Each of the individual patches was confirmed to have a positive performance impact on all supported architectures, so it *ought* to be fine as a combination patch as well.

This subsumes these patches, which can be reviewed individually:
- [Mark branches as likely/unlikely](https://github.com/lemire/simdjson/pull/316)
- [Decrease data dependencies in find_structurals](https://github.com/lemire/simdjson/pull/314)
- [Simplify and optimize flatten_bits](https://github.com/lemire/simdjson/pull/313)

It includes the basic ideas in [Unroll loop and reorder find_structural_bits](https://github.com/lemire/simdjson/pull/310) as well, but substantially revises them and interleaves the two iterations, roughly doubling the throughput improvement gain of the original patch. Ordering, unrolling and interleaving are not something that should be done in isolation, because they are pretty sensitive to the performance of the individual elements we're reordering, and some critical ones had performance substantially changed in the other patches.

I think there is a further improvement to do, now that I've understood all this--specifically, I think a pipelined design will maximize throughput and minimize the need for weird reordering like this--but I don't want to hold this up, there's a lot of hygienic changes as well as performance here.

It's your choice whether you'd like to review the patches separately or together; I fully understand the difficulty of reviewing uberpatches :) This actually descends from those submits, so if you go the piecemeal direction it won't be much work for me to resubmit just the loop and reorder changes afterwards.