### PR TITLE
Improved const correctness for ParsedJson interface

### DIFF
--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -51,9 +51,9 @@ public:
   // return false if the tape is likely wrong (e.g., you did not parse a valid
   // JSON).
   WARN_UNUSED
-  bool print_json(std::ostream &os);
+  bool print_json(std::ostream &os) const;
   WARN_UNUSED
-  bool dump_raw_tape(std::ostream &os);
+  bool dump_raw_tape(std::ostream &os) const;
 
   // all nodes are stored on the tape using a 64-bit word.
   //
@@ -91,7 +91,7 @@ public:
     // tape[current_loc++] = *((uint64_t *)&d);
   }
 
-  really_inline uint32_t get_current_loc() { return current_loc; }
+  really_inline uint32_t get_current_loc() const { return current_loc; }
 
   really_inline void annotate_previous_loc(uint32_t saved_loc, uint64_t val) {
     tape[saved_loc] |= val;

--- a/src/parsedjson.cpp
+++ b/src/parsedjson.cpp
@@ -113,7 +113,7 @@ void ParsedJson::init() {
 }
 
 WARN_UNUSED
-bool ParsedJson::print_json(std::ostream &os) {
+bool ParsedJson::print_json(std::ostream &os) const {
   if (!valid) {
     return false;
   }
@@ -241,7 +241,7 @@ bool ParsedJson::print_json(std::ostream &os) {
 }
 
 WARN_UNUSED
-bool ParsedJson::dump_raw_tape(std::ostream &os) {
+bool ParsedJson::dump_raw_tape(std::ostream &os) const {
   if (!valid) {
     return false;
   }


### PR DESCRIPTION
As per [issue 320](https://github.com/lemire/simdjson/issues/320), this PR improves the const correctness of the `ParsedJson` interface by allowing one to call (more) print/query functions on immutable objects.