### PR TITLE
case insensitive move_to_key

### DIFF
--- a/include/simdjson/parsedjsoniterator.h
+++ b/include/simdjson/parsedjsoniterator.h
@@ -339,15 +339,15 @@ void ParsedJson::BasicIterator<max_depth>::move_to_value() {
 
 template <size_t max_depth>
 bool ParsedJson::BasicIterator<max_depth>::move_to_key(const char *key) {
-  return move_to_key_impl(
+  return this->move_to_key_impl(
       key, [](const char *x, const char *y) { return strcmp(x, y) == 0; });
 }
 
 template <size_t max_depth>
 bool ParsedJson::BasicIterator<max_depth>::move_to_key_insensitive(
     const char *key) {
-  return move_to_key_impl(
-      key, [](const char *x, const char *y) { return strcmpi(x, y) == 0; });
+  return this->move_to_key_impl(
+      key, [](const char *x, const char *y) { return strcasecmp(x, y) == 0; });
 }
 
 template <size_t max_depth>

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -142,7 +142,7 @@ static inline int hamming(uint64_t input_num) {
 } // namespace simdjson
 #endif // _MSC_VER
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
 #define strcasecmp _stricmp
 #endif
 

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -142,6 +142,10 @@ static inline int hamming(uint64_t input_num) {
 } // namespace simdjson
 #endif // _MSC_VER
 
+#ifndef _MSC_VER
+#define strcasecmp _stricmp
+#endif
+
 namespace simdjson {
 // portable version of  posix_memalign
 static inline void *aligned_malloc(size_t alignment, size_t size) {


### PR DESCRIPTION
As per [issue 323](https://github.com/lemire/simdjson/issues/323), this PR introduces a case insensitive key lookup for the iterator. The proposal refactors `move_to_key` into a private `move_to_key_impl` which takes not only the key but a comparator. This way, there's no code duplication and both `move_to_key` and the newly added `move_to_key_insensitive` are added cleanly.

In principle, there should be zero overhead from the comparator.