### PR TITLE
Return UNESCAPED_CHARS immediately

### DIFF
--- a/src/haswell/simdutf8check.h
+++ b/src/haswell/simdutf8check.h
@@ -206,7 +206,7 @@ struct utf8_checker {
     }
   }
 
-  really_inline void check_next_input(simd_input in) {
+  really_inline ErrorValues check_next_input(simd_input in) {
     __m256i high_bit = _mm256_set1_epi8(0x80u);
     __m256i any_bits_on = in.reduce([&](auto a, auto b) {
       return _mm256_or_si256(a, b);
@@ -218,6 +218,7 @@ struct utf8_checker {
       // it is not ascii so we have to do heavy work
       in.each([&](auto _in) { check_utf8_bytes(_in); });
     }
+    return SUCCESS;
   }
 
   really_inline ErrorValues errors() {


### PR DESCRIPTION
Doing this gives a very small (but real) performance improvement in stage 1 on Kady Lake (Haswell+), and also reduces the amount of indirection, which will improve readability/grokkability.

Note: I attempted to do the same thing with the utf8 check, but that had a negative effect. Presumably this is because the UTF-8 error mask is in SIMD, and it's a lot more expensive to pull data from SIMD to scalar world with operations like test and movmskb. unescaped_chars_error was already scalar and didn't have that problem.