### PR TITLE
Make threads optional in the cmake build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,8 +17,8 @@ environment:
       THREADS: "OFF"
     - SIMDJSON_BUILD_STATIC: "ON"
       THREADS: "ON"
-    - SIMDJSON_BUILD_STATIC: "ON"
-      THREADS: "OFF"
+#    - SIMDJSON_BUILD_STATIC: "ON"
+#      THREADS: "OFF"
       
 build_script:
   - mkdir build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,11 +12,18 @@ platform:
 environment:
   matrix:
     - SIMDJSON_BUILD_STATIC: "OFF"
+      THREADS: "ON"
+    - SIMDJSON_BUILD_STATIC: "OFF"
+      THREADS: "OFF"
     - SIMDJSON_BUILD_STATIC: "ON"
+      THREADS: "ON"
+    - SIMDJSON_BUILD_STATIC: "ON"
+      THREADS: "OFF"
       
 build_script:
   - mkdir build
   - cd build
-  - ps: cmake -DSIMDJSON_BUILD_STATIC="$env:SIMDJSON_BUILD_STATIC" -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 ..
+  - ps: cmake -DSIMDJSON_BUILD_STATIC="$env:SIMDJSON_BUILD_STATIC" -DSIMDJSON_ENABLE_THREADS="$env:THREADS" -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM=x64 ..
   - cmake --build .
   - ctest --verbose --output-on-failure
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,8 @@ workflows:
       - clang-sse-dynamic
       - clang-sse-static
       - clang-sse-sanitize
+      - gcc-avx-threaded
+      - gcc-avx-unthreaded
 
       # TODO add windows: https://circleci.com/docs/2.0/configuration-reference/#windows
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,17 @@ commands:
 
 jobs:
 
+  gcc-avx-unthreaded:
+    description: Build, run tests and check performance on GCC 7 and AVX 2 *without* threads
+    executor: gcc7
+    environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=OFF }
+    steps: [ cmake_test ]
+  gcc-avx-threaded:
+    description: Build, run tests and check performance on GCC 7 and AVX 2 with threads
+    executor: gcc7
+    environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=ON }
+    steps: [ cmake_test ]
+
   gcc-avx:
     description: Build, run tests and check performance on GCC 7 and AVX 2
     executor: gcc7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,17 @@ jobs:
     environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=ON }
     steps: [ cmake_test ]
 
+  clang-avx-unthreaded:
+    description: Build, run tests and check performance on Clang 6 and AVX 2 *without* threads
+    executor: clang6
+    environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=OFF }
+    steps: [ cmake_test ]
+  clang-avx-threaded:
+    description: Build, run tests and check performance on Clang 6 and AVX 2 with threads
+    executor: clang6
+    environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=ON }
+    steps: [ cmake_test ]
+
   gcc-avx:
     description: Build, run tests and check performance on GCC 7 and AVX 2
     executor: gcc7
@@ -152,6 +163,8 @@ workflows:
       - clang-sse-sanitize
       - gcc-avx-threaded
       - gcc-avx-unthreaded
+      - clang-avx-threaded
+      - clang-avx-unthreaded
 
       # TODO add windows: https://circleci.com/docs/2.0/configuration-reference/#windows
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,22 +121,22 @@ jobs:
     steps: [ init_clang6, cmake_test ]
 
   clang-sse:
-    description: Build, run tests and check performance on GCC 7 and SSE 4.2
+    description: Build, run tests and check performance on Clang 6 and SSE 4.2
     executor: clang6
     environment: { ARCHFLAGS: -march=nehalem }
     steps: [ init_clang6, make_test ]
   clang-sse-dynamic:
-    description: Build, run tests and check performance on GCC 7 and SSE 4.2 with a cmake dynamic build
+    description: Build, run tests and check performance on Clang 6 and SSE 4.2 with a cmake dynamic build
     executor: clang6
     environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF }
     steps: [ init_clang6, cmake_test ]
   clang-sse-static:
-    description: Build, run tests and check performance on GCC 7 and SSE 4.2 with a cmake static build
+    description: Build, run tests and check performance on Clang 6 and SSE 4.2 with a cmake static build
     executor: clang6
     environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_BUILD_STATIC=ON }
     steps: [ init_clang6, cmake_test ]
   clang-sse-sanitize:
-    description: Build, run tests and check performance on GCC 7 and SSE 4.2 with a cmake sanitize build
+    description: Build, run tests and check performance on Clang 6 and SSE 4.2 with a cmake sanitize build
     executor: clang6
     environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON }
     steps: [ init_clang6, cmake_test ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,12 @@ jobs:
     description: Build, run tests and check performance on Clang 6 and AVX 2 *without* threads
     executor: clang6
     environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=OFF }
-    steps: [ cmake_test ]
+    steps: [ init_clang6, cmake_test ]
   clang-avx-threaded:
     description: Build, run tests and check performance on Clang 6 and AVX 2 with threads
     executor: clang6
     environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=ON }
-    steps: [ cmake_test ]
+    steps: [ init_clang6, cmake_test ]
 
   gcc-avx:
     description: Build, run tests and check performance on GCC 7 and AVX 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
 find_package(CTargets)
 find_package(Options)
-find_package(Threads REQUIRED)
 
-if(CMAKE_USE_PTHREADS_INIT)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-endif()
+option(SIMDJSON_ENABLE_THREADS "enable threaded operation" ON)
 
 install(DIRECTORY include/${SIMDJSON_LIB_NAME} DESTINATION include)
 set (TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jsonchecker/")

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -8,6 +8,4 @@ add_cpp_benchmark(parse)
 add_cpp_benchmark(statisticalmodel)
 add_cpp_benchmark(parse_stream)
 
-target_link_libraries(parse_stream Threads::Threads)
-
 add_executable(perfdiff perfdiff.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,3 +100,9 @@ if(MSVC AND (SIMDJSON_LIB_TYPE STREQUAL "SHARED"))
  set_target_properties(${SIMDJSON_LIB_NAME}
     PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
 endif()
+
+if(SIMDJSON_ENABLE_THREADS)
+  find_package(Threads REQUIRED)
+  target_link_libraries( ${SIMDJSON_LIB_NAME} Threads::Threads)
+endif()
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,6 @@ add_cpp_test(jsonstream_test)
 add_cpp_test(pointercheck)
 add_cpp_test(integer_tests)
 
-target_link_libraries(jsonstream_test Threads::Threads)
 ## This causes problems
 # add_executable(singleheader ./singleheadertest.cpp ${PROJECT_SOURCE_DIR}/singleheader/simdjson.cpp)
 # target_compile_definitions(singleheader PRIVATE JSON_TEST_PATH="${PROJECT_SOURCE_DIR}/jsonexamples/twitter.json")


### PR DESCRIPTION
After recent discussions on threads in the cmake build, this cleans up the cmake
threading handling and makes it configurable.

Update: the CI jobs seem to work, this PR is ready for review!