### PR TITLE
Switching ARM64 to lookup algo. for UTF8 validation.

### DIFF
--- a/src/arm64/stage1_find_marks.h
+++ b/src/arm64/stage1_find_marks.h
@@ -29,7 +29,7 @@ really_inline void find_whitespace_and_operators(
   whitespace = v.map([&](simd8<uint8_t> _v) { return _v.any_bits_set(0x18); }).to_bitmask();
 }
 
-#include "generic/utf8_fastvalidate_algorithm.h"
+#include "generic/utf8_lookup_algorithm.h"
 #include "generic/stage1_find_marks.h"
 
 } // namespace simdjson::arm64


### PR DESCRIPTION
First line is master, second line is this PR. We reduce the number of instructions on an Ampere server. This is motivated by results reported on twitter by [Matthew  Wilson on Amazon's ARM servers](https://twitter.com/_msw_/status/1204094270241554432).

```
jsonexamples/apache_builds.json
stage 1 instructions:     395648 cycles:     510972 (49.44 %) ins/cycles: 0.77 mis. branches:        441 (cycles/mis.branch 1156.84) cache accesses:      41394 (failure       2008)
 stage 1 runs at 4.01 cycles per input byte.
stage 1 instructions:     391668 cycles:     499066 (50.06 %) ins/cycles: 0.78 mis. branches:        445 (cycles/mis.branch 1121.28) cache accesses:      37428 (failure       2005)
 stage 1 runs at 3.92 cycles per input byte.
jsonexamples/canada.json
stage 1 instructions:    7769448 cycles:    9299349 (38.73 %) ins/cycles: 0.84 mis. branches:      11447 (cycles/mis.branch 812.33) cache accesses:     868680 (failure      35205)
 stage 1 runs at 4.13 cycles per input byte.
stage 1 instructions:    7699100 cycles:    9091796 (38.47 %) ins/cycles: 0.85 mis. branches:      11193 (cycles/mis.branch 812.23) cache accesses:     795291 (failure      35192)
 stage 1 runs at 4.04 cycles per input byte.
jsonexamples/citm_catalog.json
stage 1 instructions:    5103759 cycles:    6689454 (61.22 %) ins/cycles: 0.76 mis. branches:        474 (cycles/mis.branch 14086.03) cache accesses:     493524 (failure      27017)
 stage 1 runs at 3.87 cycles per input byte.
stage 1 instructions:    5045692 cycles:    6512326 (60.17 %) ins/cycles: 0.77 mis. branches:        477 (cycles/mis.branch 13644.09) cache accesses:     439832 (failure      27010)
 stage 1 runs at 3.77 cycles per input byte.
jsonexamples/github_events.json
stage 1 instructions:     190518 cycles:     256372 (54.02 %) ins/cycles: 0.74 mis. branches:        273 (cycles/mis.branch 936.82) cache accesses:      19374 (failure       1037)
 stage 1 runs at 3.94 cycles per input byte.
stage 1 instructions:     188386 cycles:     249423 (53.42 %) ins/cycles: 0.76 mis. branches:        281 (cycles/mis.branch 887.49) cache accesses:      17429 (failure       1038)
 stage 1 runs at 3.83 cycles per input byte.
jsonexamples/gsoc-2018.json
stage 1 instructions:    7972527 cycles:   12033929 (60.70 %) ins/cycles: 0.66 mis. branches:       9831 (cycles/mis.branch 1224.07) cache accesses:     685714 (failure      52030)
 stage 1 runs at 3.62 cycles per input byte.
stage 1 instructions:    7868529 cycles:   11630836 (59.68 %) ins/cycles: 0.68 mis. branches:       9722 (cycles/mis.branch 1196.27) cache accesses:     586378 (failure      52015)
 stage 1 runs at 3.50 cycles per input byte.
jsonexamples/instruments.json
stage 1 instructions:     700908 cycles:     889318 (51.15 %) ins/cycles: 0.79 mis. branches:        805 (cycles/mis.branch 1103.87) cache accesses:      74393 (failure       3464)
 stage 1 runs at 4.04 cycles per input byte.
^C
[dlemire@ampere simdjson]$ for i in jsonexamples/*.json ; do echo $i; ./parsemaster $i |grep "stage 1"; ./parse $i |grep "stage 1";echo; done
jsonexamples/apache_builds.json
stage 1 instructions:     395648 cycles:     511271 (50.29 %) ins/cycles: 0.77 mis. branches:        441 (cycles/mis.branch 1158.56) cache accesses:      41383 (failure       2008)
 stage 1 runs at 4.02 cycles per input byte.
stage 1 instructions:     391668 cycles:     499136 (49.76 %) ins/cycles: 0.78 mis. branches:        445 (cycles/mis.branch 1119.67) cache accesses:      37420 (failure       2005)
 stage 1 runs at 3.92 cycles per input byte.

jsonexamples/canada.json
stage 1 instructions:    7769448 cycles:    9296902 (38.72 %) ins/cycles: 0.84 mis. branches:      11433 (cycles/mis.branch 813.14) cache accesses:     866712 (failure      35207)
 stage 1 runs at 4.13 cycles per input byte.
stage 1 instructions:    7699100 cycles:    9091817 (38.52 %) ins/cycles: 0.85 mis. branches:      11214 (cycles/mis.branch 810.69) cache accesses:     795360 (failure      35192)
 stage 1 runs at 4.04 cycles per input byte.

jsonexamples/citm_catalog.json
stage 1 instructions:    5103759 cycles:    6688720 (61.04 %) ins/cycles: 0.76 mis. branches:        476 (cycles/mis.branch 14048.98) cache accesses:     493533 (failure      27020)
 stage 1 runs at 3.87 cycles per input byte.
stage 1 instructions:    5045692 cycles:    6512164 (60.20 %) ins/cycles: 0.77 mis. branches:        478 (cycles/mis.branch 13612.38) cache accesses:     439818 (failure      27011)
 stage 1 runs at 3.77 cycles per input byte.

jsonexamples/github_events.json
stage 1 instructions:     190518 cycles:     256315 (54.03 %) ins/cycles: 0.74 mis. branches:        274 (cycles/mis.branch 932.85) cache accesses:      19385 (failure       1038)
 stage 1 runs at 3.94 cycles per input byte.
stage 1 instructions:     188386 cycles:     249279 (52.58 %) ins/cycles: 0.76 mis. branches:        279 (cycles/mis.branch 893.17) cache accesses:      17427 (failure       1037)
 stage 1 runs at 3.83 cycles per input byte.

jsonexamples/gsoc-2018.json
stage 1 instructions:    7972527 cycles:   12034606 (60.70 %) ins/cycles: 0.66 mis. branches:       9884 (cycles/mis.branch 1217.47) cache accesses:     685976 (failure      52033)
 stage 1 runs at 3.62 cycles per input byte.
stage 1 instructions:    7868529 cycles:   11630319 (59.95 %) ins/cycles: 0.68 mis. branches:       9724 (cycles/mis.branch 1195.97) cache accesses:     586440 (failure      52016)
 stage 1 runs at 3.49 cycles per input byte.

jsonexamples/instruments.json
stage 1 instructions:     700908 cycles:     889314 (51.95 %) ins/cycles: 0.79 mis. branches:        805 (cycles/mis.branch 1104.22) cache accesses:      74391 (failure       3460)
 stage 1 runs at 4.04 cycles per input byte.
stage 1 instructions:     694020 cycles:     867956 (50.59 %) ins/cycles: 0.80 mis. branches:        797 (cycles/mis.branch 1088.95) cache accesses:      67525 (failure       3458)
 stage 1 runs at 3.94 cycles per input byte.

jsonexamples/marine_ik.json
stage 1 instructions:   11516659 cycles:   12726347 (37.77 %) ins/cycles: 0.90 mis. branches:      13187 (cycles/mis.branch 965.02) cache accesses:    1259742 (failure      46655)
 stage 1 runs at 4.27 cycles per input byte.
stage 1 instructions:   11415443 cycles:   12460657 (37.09 %) ins/cycles: 0.92 mis. branches:      13171 (cycles/mis.branch 946.07) cache accesses:    1166951 (failure      46632)
 stage 1 runs at 4.18 cycles per input byte.

jsonexamples/mesh.json
stage 1 instructions:    2689276 cycles:    3043518 (36.87 %) ins/cycles: 0.88 mis. branches:       1270 (cycles/mis.branch 2395.77) cache accesses:     280779 (failure      11326)
 stage 1 runs at 4.21 cycles per input byte.
stage 1 instructions:    2663119 cycles:    2974639 (36.19 %) ins/cycles: 0.90 mis. branches:       1318 (cycles/mis.branch 2255.64) cache accesses:     258179 (failure      11322)
 stage 1 runs at 4.11 cycles per input byte.

jsonexamples/mesh.pretty.json
stage 1 instructions:    4859696 cycles:    6138359 (50.43 %) ins/cycles: 0.79 mis. branches:         53 (cycles/mis.branch 114950.55) cache accesses:     480128 (failure      24672)
 stage 1 runs at 3.89 cycles per input byte.
stage 1 instructions:    4810400 cycles:    5986424 (50.17 %) ins/cycles: 0.80 mis. branches:         41 (cycles/mis.branch 144949.74) cache accesses:     430783 (failure      24665)
 stage 1 runs at 3.80 cycles per input byte.

jsonexamples/numbers.json
stage 1 instructions:     480679 cycles:     608621 (38.95 %) ins/cycles: 0.79 mis. branches:        607 (cycles/mis.branch 1002.01) cache accesses:      51171 (failure       2367)
 stage 1 runs at 4.05 cycles per input byte.
stage 1 instructions:     475985 cycles:     594873 (38.93 %) ins/cycles: 0.80 mis. branches:        604 (cycles/mis.branch 984.79) cache accesses:      46566 (failure       2365)
 stage 1 runs at 3.96 cycles per input byte.

jsonexamples/random.json
stage 1 instructions:    2641941 cycles:    3646417 (53.24 %) ins/cycles: 0.72 mis. branches:       3844 (cycles/mis.branch 948.47) cache accesses:     351210 (failure       7999)
 stage 1 runs at 7.14 cycles per input byte.
stage 1 instructions:    2384122 cycles:    3213959 (49.87 %) ins/cycles: 0.74 mis. branches:       3888 (cycles/mis.branch 826.45) cache accesses:     353782 (failure       8007)
 stage 1 runs at 6.30 cycles per input byte.

jsonexamples/twitterescaped.json
stage 1 instructions:    1672345 cycles:    2243219 (31.86 %) ins/cycles: 0.75 mis. branches:       4400 (cycles/mis.branch 509.79) cache accesses:     173620 (failure       8809)
 stage 1 runs at 3.99 cycles per input byte.
stage 1 instructions:    1654144 cycles:    2182333 (31.02 %) ins/cycles: 0.76 mis. branches:       4432 (cycles/mis.branch 492.32) cache accesses:     156256 (failure       8805)
 stage 1 runs at 3.88 cycles per input byte.

jsonexamples/twitter.json
stage 1 instructions:    2242376 cycles:    3165475 (57.99 %) ins/cycles: 0.71 mis. branches:       3306 (cycles/mis.branch 957.33) cache accesses:     257803 (failure       9897)
 stage 1 runs at 5.01 cycles per input byte.
stage 1 instructions:    2115290 cycles:    2929065 (54.65 %) ins/cycles: 0.72 mis. branches:       3251 (cycles/mis.branch 900.87) cache accesses:     247184 (failure       9903)
 stage 1 runs at 4.64 cycles per input byte.

jsonexamples/update-center.json
stage 1 instructions:    1686066 cycles:    2190073 (42.85 %) ins/cycles: 0.77 mis. branches:       4262 (cycles/mis.branch 513.81) cache accesses:     184407 (failure       8363)
 stage 1 runs at 4.11 cycles per input byte.
stage 1 instructions:    1668399 cycles:    2134226 (41.98 %) ins/cycles: 0.78 mis. branches:       4272 (cycles/mis.branch 499.49) cache accesses:     168224 (failure       8375)
 stage 1 runs at 4.00 cycles per input byte.
```