### PR TITLE
[for discussion] PMULL is sometimes slow on ARM64, let us not rely on it?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ architecture:=$(shell arch)
 # E.g., type ' ARCHFLAGS="-march=nehalem" make parse '
 ###
 ifeq ($(architecture),aarch64)
-ARCHFLAGS ?= -march=armv8-a+crc+crypto
+ARCHFLAGS ?= -march=armv8-a
 else
 ARCHFLAGS ?= -msse4.2 -mpclmul # lowest supported feature set?
 endif

--- a/src/arm64/bitmask.h
+++ b/src/arm64/bitmask.h
@@ -16,10 +16,12 @@ namespace simdjson::arm64 {
 // For example, prefix_xor(00100100) == 00011100
 //
 really_inline uint64_t prefix_xor(uint64_t bitmask) {
-
-#ifdef __ARM_FEATURE_CRYPTO // some ARM processors lack this extension
-  return vmull_p64(-1ULL, bitmask);
-#else
+  //
+  // We could do this with PMULL, but it is apparently slow.
+  //  
+  //#ifdef __ARM_FEATURE_CRYPTO // some ARM processors lack this extension
+  //return vmull_p64(-1ULL, bitmask);
+  //#else
   bitmask ^= bitmask << 1;
   bitmask ^= bitmask << 2;
   bitmask ^= bitmask << 4;
@@ -27,8 +29,6 @@ really_inline uint64_t prefix_xor(uint64_t bitmask) {
   bitmask ^= bitmask << 16;
   bitmask ^= bitmask << 32;
   return bitmask;
-#endif
-
 }
 
 } // namespace simdjson::arm64


### PR DESCRIPTION
On some ARM platforms, PMULL is slow.

In theory, PMULL has a throughout of one instruction per cycle with a latency of 4 or 5 cycles on some platforms like the [A53](http://infocenter.arm.com/help/topic/com.arm.doc.uan0015b/Cortex_A57_Software_Optimization_Guide_external.pdf) or 4 cycles on  the [A72](http://infocenter.arm.com/help/topic/com.arm.doc.uan0016a/cortex_a72_software_optimization_guide_external.pdf). That's better than the portable approach which might compile to the following...

```
  eor x0, x0, x0, lsl 1
  eor x0, x0, x0, lsl 2
  eor x0, x0, x0, lsl 4
  eor x0, x0, x0, lsl 8
  eor x0, x0, x0, lsl 16
  eor x0, x0, x0, lsl 32
```

I would expect this sequence to havre a latency of 6 cycles... However, a pure latency analysis might be misleading here.

Which is better, six calls to `eor` or a single call to `PMULL`?

[Matthew Wilson reports better on results on Amazon's Graviton 2 with the `eor` sequence](https://twitter.com/_msw_/status/1204140642961510400).

Let us benchmark it on my Ampere server. 

For each file, the first line is master, the second line is this PR. The number of instructions is up, but the number of cycles is also down...

```

jsonexamples/apache_builds.json
stage 1 instructions:     395648 cycles:     510917 (49.27 %) ins/cycles: 0.77 mis. branches:        441 (cycles/mis.branch 1156.32) cache accesses:      41387 (failure       2008)
 stage 1 runs at 4.01 cycles per input byte.
stage 1 instructions:     401613 cycles:     501762 (49.08 %) ins/cycles: 0.80 mis. branches:        446 (cycles/mis.branch 1123.77) cache accesses:      41412 (failure       2007)
 stage 1 runs at 3.94 cycles per input byte.

jsonexamples/canada.json
stage 1 instructions:    7769448 cycles:    9298402 (38.66 %) ins/cycles: 0.84 mis. branches:      11425 (cycles/mis.branch 813.81) cache accesses:     868509 (failure      35204)
 stage 1 runs at 4.13 cycles per input byte.
stage 1 instructions:    7874965 cycles:    9159878 (38.30 %) ins/cycles: 0.86 mis. branches:      11175 (cycles/mis.branch 819.61) cache accesses:     865310 (failure      35205)
 stage 1 runs at 4.07 cycles per input byte.

jsonexamples/citm_catalog.json
stage 1 instructions:    5103759 cycles:    6689623 (60.86 %) ins/cycles: 0.76 mis. branches:        478 (cycles/mis.branch 13977.48) cache accesses:     493554 (failure      27019)
 stage 1 runs at 3.87 cycles per input byte.
stage 1 instructions:    5184199 cycles:    6533712 (60.86 %) ins/cycles: 0.79 mis. branches:        470 (cycles/mis.branch 13886.74) cache accesses:     493180 (failure      27015)
 stage 1 runs at 3.78 cycles per input byte.

jsonexamples/github_events.json
stage 1 instructions:     190518 cycles:     256389 (52.20 %) ins/cycles: 0.74 mis. branches:        275 (cycles/mis.branch 930.19) cache accesses:      19379 (failure       1037)
 stage 1 runs at 3.94 cycles per input byte.
stage 1 instructions:     193558 cycles:     251020 (53.51 %) ins/cycles: 0.77 mis. branches:        275 (cycles/mis.branch 910.86) cache accesses:      19295 (failure       1035)
 stage 1 runs at 3.85 cycles per input byte.

jsonexamples/gsoc-2018.json
stage 1 instructions:    7972527 cycles:   12035523 (60.80 %) ins/cycles: 0.66 mis. branches:       9923 (cycles/mis.branch 1212.88) cache accesses:     685984 (failure      52030)
 stage 1 runs at 3.62 cycles per input byte.
stage 1 instructions:    8128519 cycles:   11768620 (60.24 %) ins/cycles: 0.69 mis. branches:       9913 (cycles/mis.branch 1187.18) cache accesses:     673626 (failure      52032)
 stage 1 runs at 3.54 cycles per input byte.

jsonexamples/instruments.json
stage 1 instructions:     700908 cycles:     888843 (50.97 %) ins/cycles: 0.79 mis. branches:        805 (cycles/mis.branch 1103.68) cache accesses:      74402 (failure       3464)
 stage 1 runs at 4.03 cycles per input byte.
stage 1 instructions:     711235 cycles:     872224 (50.28 %) ins/cycles: 0.82 mis. branches:        796 (cycles/mis.branch 1094.82) cache accesses:      74378 (failure       3462)
 stage 1 runs at 3.96 cycles per input byte.

jsonexamples/marine_ik.json
stage 1 instructions:   11516659 cycles:   12726226 (37.59 %) ins/cycles: 0.90 mis. branches:      13214 (cycles/mis.branch 963.05) cache accesses:    1259831 (failure      46653)
 stage 1 runs at 4.27 cycles per input byte.
stage 1 instructions:   11656508 cycles:   12547133 (37.30 %) ins/cycles: 0.93 mis. branches:      13133 (cycles/mis.branch 955.34) cache accesses:    1257140 (failure      46655)
 stage 1 runs at 4.21 cycles per input byte.

jsonexamples/mesh.json
stage 1 instructions:    2689276 cycles:    3043827 (36.55 %) ins/cycles: 0.88 mis. branches:       1270 (cycles/mis.branch 2395.83) cache accesses:     280843 (failure      11327)
 stage 1 runs at 4.21 cycles per input byte.
stage 1 instructions:    2723195 cycles:    2983616 (36.32 %) ins/cycles: 0.91 mis. branches:       1274 (cycles/mis.branch 2341.80) cache accesses:     280656 (failure      11328)
 stage 1 runs at 4.12 cycles per input byte.

jsonexamples/mesh.pretty.json
stage 1 instructions:    4859696 cycles:    6138626 (50.72 %) ins/cycles: 0.79 mis. branches:         51 (cycles/mis.branch 118277.97) cache accesses:     480123 (failure      24672)
 stage 1 runs at 3.89 cycles per input byte.
stage 1 instructions:    4933635 cycles:    6009036 (49.95 %) ins/cycles: 0.82 mis. branches:         49 (cycles/mis.branch 121887.15) cache accesses:     480120 (failure      24672)
 stage 1 runs at 3.81 cycles per input byte.

jsonexamples/numbers.json
stage 1 instructions:     480679 cycles:     608430 (39.07 %) ins/cycles: 0.79 mis. branches:        604 (cycles/mis.branch 1006.23) cache accesses:      51214 (failure       2366)
 stage 1 runs at 4.05 cycles per input byte.
stage 1 instructions:     487715 cycles:     597699 (38.90 %) ins/cycles: 0.82 mis. branches:        602 (cycles/mis.branch 992.52) cache accesses:      51268 (failure       2365)
 stage 1 runs at 3.98 cycles per input byte.

jsonexamples/random.json
stage 1 instructions:    2641941 cycles:    3645776 (53.45 %) ins/cycles: 0.72 mis. branches:       3843 (cycles/mis.branch 948.48) cache accesses:     351207 (failure       8000)
 stage 1 runs at 7.14 cycles per input byte.
stage 1 instructions:    2634994 cycles:    3575589 (52.90 %) ins/cycles: 0.74 mis. branches:       3868 (cycles/mis.branch 924.18) cache accesses:     330869 (failure       8001)
 stage 1 runs at 7.00 cycles per input byte.

jsonexamples/twitterescaped.json
stage 1 instructions:    1672345 cycles:    2243466 (31.81 %) ins/cycles: 0.75 mis. branches:       4397 (cycles/mis.branch 510.18) cache accesses:     173627 (failure       8809)
 stage 1 runs at 3.99 cycles per input byte.
stage 1 instructions:    1698707 cycles:    2203133 (31.43 %) ins/cycles: 0.77 mis. branches:       4414 (cycles/mis.branch 499.03) cache accesses:     171580 (failure       8811)
 stage 1 runs at 3.92 cycles per input byte.

jsonexamples/twitter.json
stage 1 instructions:    2242376 cycles:    3166166 (57.19 %) ins/cycles: 0.71 mis. branches:       3307 (cycles/mis.branch 957.23) cache accesses:     257814 (failure       9896)
 stage 1 runs at 5.01 cycles per input byte.
stage 1 instructions:    2258274 cycles:    3098090 (57.01 %) ins/cycles: 0.73 mis. branches:       3374 (cycles/mis.branch 918.00) cache accesses:     248873 (failure       9901)
 stage 1 runs at 4.91 cycles per input byte.

jsonexamples/update-center.json
stage 1 instructions:    1686066 cycles:    2190297 (43.27 %) ins/cycles: 0.77 mis. branches:       4264 (cycles/mis.branch 513.63) cache accesses:     184461 (failure       8364)
 stage 1 runs at 4.11 cycles per input byte.
stage 1 instructions:    1710943 cycles:    2153359 (42.49 %) ins/cycles: 0.79 mis. branches:       4263 (cycles/mis.branch 505.03) cache accesses:     183427 (failure       8367)
 stage 1 runs at 4.04 cycles per input byte.
```