### PR TITLE
Incorporate actual miss rate in feature benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ LIBFILES=src/jsonioutil.cpp src/jsonparser.cpp src/jsonstream.cpp src/simdjson.c
 MINIFIERHEADERS=include/simdjson/jsonminifier.h
 MINIFIERLIBFILES=src/jsonminifier.cpp
 
+FEATURE_JSON_FILES=jsonexamples/generated/0-structurals-full.json jsonexamples/generated/15-structurals-miss.json jsonexamples/generated/7-structurals.json jsonexamples/generated/0-structurals.json jsonexamples/generated/23-structurals-full.json jsonexamples/generated/7-structurals-miss.json jsonexamples/generated/0-structurals-miss.json jsonexamples/generated/23-structurals.json jsonexamples/generated/utf-8-full.json jsonexamples/generated/15-structurals-full.json jsonexamples/generated/23-structurals-miss.json jsonexamples/generated/utf-8.json jsonexamples/generated/15-structurals.json jsonexamples/generated/7-structurals-full.json jsonexamples/generated/utf-8-miss.json
 
 RAPIDJSON_INCLUDE:=dependencies/rapidjson/include
 SAJSON_INCLUDE:=dependencies/sajson/include
@@ -126,10 +127,10 @@ run_issue150_sh: allparserscheckfile
 run_testjson2json_sh: minify json2json
 	./scripts/testjson2json.sh
 
-generate_featurejson:
+$(FEATURE_JSON_FILES): benchmark/genfeaturejson.rb
 	ruby ./benchmark/genfeaturejson.rb
 
-run_benchfeatures: benchfeatures generate_featurejson
+run_benchfeatures: benchfeatures $(FEATURE_JSON_FILES)
 	./benchfeatures -n 1000
 
 test: run_basictests run_jsoncheck run_numberparsingcheck run_integer_tests run_stringparsingcheck  run_jsonstream_test run_pointercheck run_testjson2json_sh run_issue150_sh run_jsoncheck_noavx


### PR DESCRIPTION
This takes into account the actual miss rate, displaying it (since it makes such a huge difference). Before, we estimated miss rate == flip rate, when miss rate can vary by many other code factors.

I also used it to adjust the effectiveness rating, adjusting for the misses that went wrong. Turns out if we account for the miss rate, our new estimate is pretty accurate (within 5%), even if we were 20% off without adjusting. indicating the feature measurement is probably working pretty well. Sample skylake output (it outputs Markdown tables because we paste them so often):

> Features in ns/block (64 bytes):
> 
> | Stage    |     Base | 7 Struct |    UTF-8 |  15 Str. | 16+ Str. |   7 Struct Miss |      UTF-8 Miss |    15 Str. Miss |   16+ Str. Miss |
> |----------|----------|----------|----------|----------|----------|-----------------|-----------------|-----------------|-----------------|
> | Stage 1  |     7.57 |     2.88 |     6.21 |     2.97 |      3.9 |     0.97 ( 34%) |     7.24 ( 88%) |     3.12 ( 61%) |     4.43 ( 89%) |
> 
> Estimated vs. Actual ns/block for real files:
> 
> | File            | Est. (Base) | Est. (Miss) |     Est. |   Actual |     Diff |   Est. Misses | Actual Misses | Diff (Misses) | Adjusted Miss | Adjusted Diff |
> |-----------------|-------------|-------------|----------|----------|----------|---------------|---------------|---------------|---------------|---------------|
> | gsoc-2018.json  |        8.57 |       0.184 |     8.75 |     9.04 |   +0.291 |          4930 |          5564 |          +634 |         0.207 |        +0.268 |
> | twitter.json    |        12.5 |        1.25 |     13.7 |       13 |   -0.752 |          2893 |          1473 |         -1420 |         0.637 |        -0.138 |
> | random.json     |        17.3 |        3.76 |     21.1 |     17.6 |    -3.43 |          4762 |          1117 |         -3645 |         0.883 |        -0.546 |