### PR TITLE
try to output failed fuzz cases

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       allfuzzers: parser dump
+      artifactsprefix: -artifact_prefix=fuzzfailure/
     steps:
     - name: Install packages necessary for building
       run: |
@@ -44,7 +45,7 @@ jobs:
     - name: Verify that the oss-fuzz seed corpus passes without problems
       run: |
         mkdir seedcorpus
-        unzip -d seedcorpus seed_corpus.zip
+        unzip -q -d seedcorpus seed_corpus.zip
         for buildvariant in noavx withavx; do
           for fuzzer in $allfuzzers; do
             build-ossfuzz-$buildvariant/fuzz/fuzz_$fuzzer seedcorpus -max_total_time=1
@@ -54,17 +55,27 @@ jobs:
       run: |
         for fuzzer in $allfuzzers; do
           mkdir -p out/$fuzzer # in case this is a new fuzzer, or corpus.tar is broken
-          build-ossfuzz-fast8/fuzz/fuzz_$fuzzer         out/$fuzzer -max_total_time=30
+          build-ossfuzz-fast8/fuzz/fuzz_$fuzzer         out/$fuzzer -max_total_time=30 $artifactsprefix || touch failed
+          # make sure the failing output is visible in the log
+          if [ -e failed ] ; then
+            ls fuzzfailure/* |xargs -n1 base64
+            exit 1
+          fi
         done
     - name: Run the other fuzzer variants for $fuzzer, with sanitizers etc
       run: |
         for fuzzer in $allfuzzers; do      
-          build-ossfuzz-withavx/fuzz/fuzz_$fuzzer       out/$fuzzer -max_total_time=20
-          build-ossfuzz-noavx/fuzz/fuzz_$fuzzer         out/$fuzzer -max_total_time=10
-          build-ossfuzz-noavx8/fuzz/fuzz_$fuzzer        out/$fuzzer -max_total_time=10
+          build-ossfuzz-withavx/fuzz/fuzz_$fuzzer       out/$fuzzer -max_total_time=20 $artifactsprefix || touch failed
+          build-ossfuzz-noavx/fuzz/fuzz_$fuzzer         out/$fuzzer -max_total_time=10 $artifactsprefix || touch failed
+          build-ossfuzz-noavx8/fuzz/fuzz_$fuzzer        out/$fuzzer -max_total_time=10 $artifactsprefix || touch failed
+          if [ -e failed ] ; then
+            # make sure the failing output is visible in the log
+            ls fuzzfailure/* |xargs -n1 base64
+            exit 1
+          fi
           echo disable msan runs, it fails inside the fuzzing engine and not the fuzzed code!
-          echo build-ossfuzz-msan-noavx8/fuzz/fuzz_$fuzzer   out/$fuzzer -max_total_time=10 -reload=0
-          echo build-ossfuzz-msan-withavx8/fuzz/fuzz_$fuzzer out/$fuzzer -max_total_time=10 -reload=0
+          echo build-ossfuzz-msan-noavx8/fuzz/fuzz_$fuzzer   out/$fuzzer -max_total_time=10 -reload=0 $artifactsprefix
+          echo build-ossfuzz-msan-withavx8/fuzz/fuzz_$fuzzer out/$fuzzer -max_total_time=10 -reload=0 $artifactsprefix
           echo now have $(ls out/$fuzzer |wc -l) files in corpus        
         done
     - name: Minimize the corpus with the fast fuzzer


### PR DESCRIPTION
this is to get more debug output from cases like this:
https://github.com/lemire/simdjson/commit/c9cd8e62111a7b25c240bea08a175de5ec6f8def/checks?check_suite_id=351526761
https://pipelines.actions.githubusercontent.com/gFSIASDqcDhMdHkcuMJEdsUcdOsOrVBr8d56BjAkszcoMkibGp/_apis/pipelines/1/runs/274/signedlogcontent/3?urlExpires=2019-12-21T18%3A50%3A08.3387613Z&urlSigningMethod=HMACV1&urlSignature=DVF3u4jEs81xJP6Hmi8LLQlLOztJke8MsP62J0MXruQ%3D

which ends with:
2019-12-20T23:08:42.6830393Z ../src/generic/numberparsing.h:243:31: runtime error: 1e+311 is outside the range of representable values of type 'double'
2019-12-20T23:08:42.6836790Z SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../src/generic/numberparsing.h:243:31 in
2019-12-20T23:08:42.6837715Z MS: 2 InsertRepeatedBytes-CrossOver-; base unit: 47cf79b80bc84f2ec8b39c1c73daa6c1222ef624
2019-12-20T23:08:42.6866416Z artifact_prefix='./'; Test unit written to ./crash-3fa2f47d980d4bf5812af18fb0d0a0ce9b5cc65a
2019-12-20T23:08:42.6999448Z ##[error]Process completed with exit code 1.
2019-12-20T23:08:42.7030863Z Cleaning up orphan processes


The problem is that github actions does not store artifacts on failure.