### PR TITLE
[WIP] Simplifying stage 2 - more flexible code

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -325,6 +325,12 @@ struct benchmarker {
     }
     // Calculate stats the first time we parse
     if (stats == NULL) {
+      // Because the interleave not scan all of the JSON at once, it is not possible
+      // to just have all of the stats. in one data structure, so let us run stage 1 alone.
+      int result_s1 = parser.stage1((const uint8_t *)json.data(), json.size(), pj);
+      if (result_s1 != simdjson::SUCCESS) {
+        exit_error(string("Failed to parse ") + filename + " during stage 1: " + pj.get_error_message());
+      }
       stats = new json_stats(json, pj);
     }
   }
@@ -452,7 +458,8 @@ struct benchmarker {
       print_aggregate("|    ", stage2.best);
     }
   }
-void print_interleave(bool tabbed_output) const {
+
+  void print_interleave(bool tabbed_output) const {
     if (tabbed_output) {
       char* filename_copy = (char*)malloc(strlen(filename)+1);
       strcpy(filename_copy, filename);

--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -225,7 +225,7 @@ int main(int argc, char *argv[]) {
     }
   }
   if (!options.verbose) { progress.erase(); }
-
+printf("options.tabbed_output %d\n",options.tabbed_output);
   for (size_t i=0; i<options.files.size(); i++) {
     if(options.interleave) {
       benchmarkers[i]->print_interleave(options.tabbed_output);

--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -225,7 +225,6 @@ int main(int argc, char *argv[]) {
     }
   }
   if (!options.verbose) { progress.erase(); }
-printf("options.tabbed_output %d\n",options.tabbed_output);
   for (size_t i=0; i<options.files.size(); i++) {
     if(options.interleave) {
       benchmarkers[i]->print_interleave(options.tabbed_output);

--- a/include/simdjson/jsonparser.h
+++ b/include/simdjson/jsonparser.h
@@ -11,6 +11,8 @@
 #include <string>
 
 namespace simdjson {
+
+// (This is not meant for end users, see json_parse.)
 // json_parse_implementation is the generic function, it is specialized for
 // various architectures, e.g., as
 // json_parse_implementation<Architecture::HASWELL> or
@@ -45,148 +47,7 @@ int json_parse_implementation(const uint8_t *buf, size_t len, ParsedJson &pj,
   }
   return res;
 }
-namespace {
 
-typedef struct {
-  size_t last_index;
-  size_t last_buf_index;
-  bool has_error;
-} last_index_t;
-
-last_index_t find_last_open_brace(const uint8_t *buf, size_t len,
-                                  ParsedJson &pj) {
-  last_index_t answer;
-  if (pj.n_structural_indexes == 0) {
-    answer.has_error = true;
-    return answer;
-  }
-  uint32_t largest = pj.n_structural_indexes - 1;
-  if (pj.structural_indexes[largest] == len) {
-    if (largest == 0) {
-      answer.has_error = true;
-      return answer;
-    }
-    largest--;
-  }
-  size_t i = largest;
-  for (; i >= 1; i--) {
-    char c = buf[pj.structural_indexes[i]];
-    if ((c == '{') || (c == '[')) {
-      break;
-    }
-  }
-  if (i == 0) {
-    answer.has_error = true;
-    return answer;
-  }
-  answer.has_error = false;
-  answer.last_index = i;
-  answer.last_buf_index = pj.structural_indexes[i];
-  return answer;
-}
-}
-
-// interleaved_json_parse_implementation is the generic function, it is
-// specialized for
-// various architectures, e.g., as
-// interleaved_json_parse_implementation<Architecture::HASWELL> or
-// interleaved_json_parse_implementation<Architecture::ARM64>
-template <Architecture T>
-int interleaved_json_parse_implementation(const uint8_t *buf, size_t len,
-                                          ParsedJson &pj, size_t window,
-                                          bool realloc_if_needed = true) {
-  if (pj.byte_capacity < len) {
-    pj.error_code = simdjson::CAPACITY;
-    return pj.error_code;
-  }
-  if (window <= 0) {
-    pj.error_code = simdjson::WINDOW_ERROR;
-    return pj.error_code;
-  }
-  bool reallocated = false;
-  if (realloc_if_needed) {
-    const uint8_t *tmp_buf = buf;
-    buf = (uint8_t *)allocate_padded_buffer(len);
-    if (buf == NULL)
-      return simdjson::MEMALLOC;
-    memcpy((void *)buf, tmp_buf, len);
-    reallocated = true;
-  } // if(realloc_if_needed) {
-
-  size_t idx = 0;
-  size_t actual_window = window > len ? len : window;
-  bool last_window = false;
-  if (window >= len)
-    last_window = true;
-  int stage1_is_ok =
-      find_structural_bits<T>(buf, actual_window, pj, !last_window);
-  if (stage1_is_ok != simdjson::SUCCESS) {
-    pj.error_code = stage1_is_ok;
-    if (reallocated) {
-      aligned_free((void *)buf);
-    }
-    return pj.error_code;
-  }
-  int stage2_is_ok = unified_machine_init(buf, actual_window, pj);
-  if (stage2_is_ok != simdjson::SUCCESS_AND_HAS_MORE) {
-    pj.error_code = stage2_is_ok;
-    if (reallocated) {
-      aligned_free((void *)buf);
-    }
-    return pj.error_code;
-  }
-  while (idx + window < len) {
-    actual_window = window;
-    stage1_is_ok = find_structural_bits<T>(buf + idx, actual_window, pj, true);
-    if (stage1_is_ok != simdjson::SUCCESS) {
-      pj.error_code = stage1_is_ok;
-      if (reallocated) {
-        aligned_free((void *)buf);
-      }
-      return pj.error_code;
-    }
-    last_index_t last_open_brace_index =
-        find_last_open_brace(buf + idx, actual_window, pj);
-    if (last_open_brace_index.has_error) {
-      pj.error_code = simdjson::WINDOW_ERROR;
-      if (reallocated) {
-        aligned_free((void *)buf);
-      }
-      return pj.error_code;
-    }
-    actual_window = last_open_brace_index.last_buf_index;
-    stage2_is_ok = unified_machine_continue<T>(
-        buf + idx, actual_window, pj, last_open_brace_index.last_index);
-    if (stage2_is_ok != simdjson::SUCCESS_AND_HAS_MORE) {
-      pj.error_code = stage2_is_ok;
-      if (reallocated) {
-        aligned_free((void *)buf);
-      }
-      return stage2_is_ok;
-    }
-    idx += actual_window;
-  }
-  if (idx < len) {
-    actual_window = len - idx;
-    stage1_is_ok = find_structural_bits<T>(buf + idx, actual_window, pj, false);
-
-    if (stage1_is_ok != simdjson::SUCCESS) {
-      pj.error_code = stage1_is_ok;
-      if (reallocated) {
-        aligned_free((void *)buf);
-      }
-      return pj.error_code;
-    }
-    stage2_is_ok =
-        unified_machine_finish<T>(buf + idx, actual_window, pj);
-    idx += actual_window;
-  }
-  pj.error_code = stage2_is_ok;
-  if (reallocated) {
-    aligned_free((void *)buf);
-  }
-  return pj.error_code;
-}
 
 
 // Parse a document found in buf.
@@ -215,6 +76,7 @@ int interleaved_json_parse_implementation(const uint8_t *buf, size_t len,
 
 int json_parse(const uint8_t *buf, size_t len, ParsedJson &pj,
                bool realloc_if_needed = true);
+
 
 // Parse a document found in buf.
 //
@@ -362,5 +224,171 @@ inline ParsedJson build_parsed_json(const padded_string &s) {
   return build_parsed_json(s.data(), s.length(), false);
 }
 
+
+///////////////////////////
+// Interleave
+///////////////////////////
+
+namespace {
+
+typedef struct {
+  size_t last_index;
+  size_t last_buf_index;
+  bool has_error;
+} last_index_t;
+
+last_index_t find_last_open_brace(const uint8_t *buf, size_t len,
+                                  ParsedJson &pj) {
+  last_index_t answer;
+  if (pj.n_structural_indexes == 0) {
+    answer.has_error = true;
+    return answer;
+  }
+  uint32_t largest = pj.n_structural_indexes - 1;
+  if (pj.structural_indexes[largest] == len) {
+    if (largest == 0) {
+      answer.has_error = true;
+      return answer;
+    }
+    largest--;
+  }
+  size_t i = largest;
+  for (; i >= 1; i--) {
+    char c = buf[pj.structural_indexes[i]];
+    if ((c == '{') || (c == '[')) {
+      break;
+    }
+  }
+  if (i == 0) {
+    answer.has_error = true;
+    return answer;
+  }
+  answer.has_error = false;
+  answer.last_index = i;
+  answer.last_buf_index = pj.structural_indexes[i];
+  return answer;
+}
+}
+
+// interleaved_json_parse_implementation is the generic function, it is
+// specialized for
+// various architectures, e.g., as
+// interleaved_json_parse_implementation<Architecture::HASWELL> or
+// interleaved_json_parse_implementation<Architecture::ARM64>
+// (This is not meant for end users, see interleaved_json_parse.)
+template <Architecture T>
+int interleaved_json_parse_implementation(const uint8_t *buf, size_t len,
+                                          ParsedJson &pj, size_t window,
+                                          bool realloc_if_needed = true) {
+  if (pj.byte_capacity < len) {
+    pj.error_code = simdjson::CAPACITY;
+    return pj.error_code;
+  }
+  if (window <= 0) {
+    pj.error_code = simdjson::WINDOW_ERROR;
+    return pj.error_code;
+  }
+  bool reallocated = false;
+  if (realloc_if_needed) {
+    const uint8_t *tmp_buf = buf;
+    buf = (uint8_t *)allocate_padded_buffer(len);
+    if (buf == NULL)
+      return simdjson::MEMALLOC;
+    memcpy((void *)buf, tmp_buf, len);
+    reallocated = true;
+  } // if(realloc_if_needed) {
+
+  size_t idx = 0;
+  size_t actual_window = window > len ? len : window;
+  bool last_window = false;
+  if (window >= len)
+    last_window = true;
+  int stage1_is_ok =
+      find_structural_bits<T>(buf, actual_window, pj, !last_window);
+  if (stage1_is_ok != simdjson::SUCCESS) {
+    pj.error_code = stage1_is_ok;
+    if (reallocated) {
+      aligned_free((void *)buf);
+    }
+    return pj.error_code;
+  }
+  int stage2_is_ok = unified_machine_init(buf, actual_window, pj);
+  if (stage2_is_ok != simdjson::SUCCESS_AND_HAS_MORE) {
+    pj.error_code = stage2_is_ok;
+    if (reallocated) {
+      aligned_free((void *)buf);
+    }
+    return pj.error_code;
+  }
+  bool need_stage1 = false;
+  while (idx + window < len) {
+    actual_window = window;
+    if(need_stage1) { // first time around, we don't need stage 1
+      stage1_is_ok = find_structural_bits<T>(buf + idx, actual_window, pj, true);
+      if (stage1_is_ok != simdjson::SUCCESS) {
+        pj.error_code = stage1_is_ok;
+        if (reallocated) {
+          aligned_free((void *)buf);
+        }
+        return pj.error_code;
+      }
+    } else {
+      need_stage1 = true; // next round, we are going to need stage 1
+    }
+    last_index_t last_open_brace_index =
+        find_last_open_brace(buf + idx, actual_window, pj);
+    if (last_open_brace_index.has_error) {
+      pj.error_code = simdjson::WINDOW_ERROR;
+      if (reallocated) {
+        aligned_free((void *)buf);
+      }
+      return pj.error_code;
+    }
+    actual_window = last_open_brace_index.last_buf_index;
+    stage2_is_ok = unified_machine_continue<T>(
+        buf + idx, actual_window, pj, last_open_brace_index.last_index);
+    if (stage2_is_ok != simdjson::SUCCESS_AND_HAS_MORE) {
+      pj.error_code = stage2_is_ok;
+      if (reallocated) {
+        aligned_free((void *)buf);
+      }
+      return stage2_is_ok;
+    }
+    idx += actual_window;
+  }
+  if (idx < len) {
+    actual_window = len - idx;
+    if(need_stage1) { // we could make it at this point without needing stage 1
+      stage1_is_ok = find_structural_bits<T>(buf + idx, actual_window, pj, false);
+      if (stage1_is_ok != simdjson::SUCCESS) {
+        pj.error_code = stage1_is_ok;
+        if (reallocated) {
+          aligned_free((void *)buf);
+        }
+        return pj.error_code;
+      }
+    }
+    stage2_is_ok =
+        unified_machine_finish<T>(buf + idx, actual_window, pj);
+    idx += actual_window; // should be unnecessary
+  }
+  pj.error_code = stage2_is_ok;
+  if (reallocated) {
+    aligned_free((void *)buf);
+  }
+  return pj.error_code;
+}
+
+// like json_parse but parses the document in chunks of "window" bytes
+int interleaved_json_parse(const uint8_t *buf, size_t len, ParsedJson &pj,
+               size_t window, bool realloc_if_needed = true);
+int interleaved_json_parse(const char *buf, size_t len, ParsedJson &pj,
+               size_t window, bool realloc_if_needed = true);
+inline int interleaved_json_parse(const std::string &s, ParsedJson &pj, size_t window) {
+  return interleaved_json_parse(s.data(), s.length(), pj, window, true);
+}
+inline int interleaved_json_parse(const padded_string &s, ParsedJson &pj, size_t window) {
+  return interleaved_json_parse(s.data(), s.length(), pj, window, false);
+}
 } // namespace simdjson
 #endif

--- a/include/simdjson/jsonparser.h
+++ b/include/simdjson/jsonparser.h
@@ -71,7 +71,7 @@ last_index_t find_last_open_brace(const uint8_t *buf, size_t len,
   for (; i >= 1; i--) {
 
     char c = buf[pj.structural_indexes[i]];
-    printf("i = %d (%zu) %c \n", i,pj.structural_indexes[i],c);
+    printf("i = %zu (%u) %c \n", i,pj.structural_indexes[i],c);
     if ((c == '{') || (c == '[')) {
       printf("structural char at %u = %c\n", pj.structural_indexes[i],
            buf[pj.structural_indexes[i]]);
@@ -118,7 +118,7 @@ int interleaved_json_parse_implementation(const uint8_t *buf, size_t len,
   size_t idx = 0;
   size_t actual_window = window > len ? len : window;
   bool last_window = false;
-  printf("windo = %d len = %d \n", window, len);
+  printf("windo = %zu len = %zu \n", window, len);
   if (window >= len)
     last_window = true;
   if (last_window)
@@ -144,38 +144,6 @@ int interleaved_json_parse_implementation(const uint8_t *buf, size_t len,
     }
     return pj.error_code;
   }
-  /*printf("unified_machine_init ok\n");
-  if (last_window) {
-    printf("finishing\n");
-
-    stage2_is_ok = unified_machine_finish<T>(buf, actual_window, pj, status);
-  } else {
-    printf("hitting the first window\n");
-    last_index_t last_open_brace_index =
-        find_last_open_brace(buf, actual_window, pj);
-    if (last_open_brace_index.has_error) {
-      pj.error_code = simdjson::EMPTY;
-      if (reallocated) {
-        aligned_free((void *)buf);
-      }
-      return pj.error_code;
-    }
-    actual_window = last_open_brace_index.last_buf_index + 1;
-    // we have to identify the first start of scope
-    stage2_is_ok = unified_machine_continue<T>(
-        buf + idx, actual_window, pj, status, last_open_brace_index.last_index);
-    printf("unified_machine_continue returned %d\n", stage2_is_ok);
-  }
-  if (stage2_is_ok != simdjson::SUCCESS_AND_HAS_MORE) {
-    pj.error_code = stage2_is_ok;
-    if (reallocated) {
-      aligned_free((void *)buf);
-    }
-    return pj.error_code;
-  }
-  printf("the first window is ok\n");
-  idx += actual_window;*/
-
   while (idx + window < len) {
     printf("========================= idx = %zu string = %.32s \n", idx, buf+idx);
     actual_window = window;
@@ -191,7 +159,7 @@ int interleaved_json_parse_implementation(const uint8_t *buf, size_t len,
     last_index_t last_open_brace_index =
         find_last_open_brace(buf + idx, actual_window, pj);
     if (last_open_brace_index.has_error) {
-      pj.error_code = simdjson::EMPTY;
+      pj.error_code = simdjson::WINDOW_ERROR;
       if (reallocated) {
         aligned_free((void *)buf);
       }
@@ -205,9 +173,9 @@ printf("I am going to run unified machine on @@@@%.32s@@@@\n", buf+idx);
 status.current_index = 0;
     stage2_is_ok = unified_machine_continue<T>(
         buf + idx, actual_window, pj, status, last_open_brace_index.last_index);
-        printf("stage2 depth = %zu latest index = %zu \n", status.current_depth, status.current_index);
+        printf("stage2 depth = %u latest index = %zu \n", status.current_depth, status.current_index);
     if (stage2_is_ok != simdjson::SUCCESS_AND_HAS_MORE) {
-      printf("stage2 returned %zu\n", stage2_is_ok);
+      printf("stage2 returned %dz\n", stage2_is_ok);
       pj.error_code = stage2_is_ok;
       if (reallocated) {
         aligned_free((void *)buf);

--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -120,13 +120,14 @@ public:
 #ifdef SIMDJSON_USE_COMPUTED_GOTO
   void **ret_address;
 #else
-  bool *ret_address;
+  char *ret_address;
 #endif
 
   uint8_t *string_buf; // should be at least byte_capacity
   uint8_t *current_string_buf_loc;
   bool valid{false};
   int error_code{simdjson::UNITIALIZED};
+  uint32_t current_depth{0}; // used by unified_machine_continue
 
 private:
   // we don't want the default constructor to be called

--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -120,7 +120,7 @@ public:
 #ifdef SIMDJSON_USE_COMPUTED_GOTO
   void **ret_address;
 #else
-  char *ret_address;
+  bool *ret_address;
 #endif
 
   uint8_t *string_buf; // should be at least byte_capacity

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -9,14 +9,12 @@
 #include <iso646.h>
 #endif
 
-
 #if defined(__x86_64__) || defined(_M_AMD64)
 #define IS_X86_64 1
 #endif
 #if defined(__aarch64__) || defined(_M_ARM64)
 #define IS_ARM64 1
 #endif
-
 
 // this is almost standard?
 #undef STRINGIFY_IMPLEMENTATION_

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -9,12 +9,14 @@
 #include <iso646.h>
 #endif
 
+
 #if defined(__x86_64__) || defined(_M_AMD64)
 #define IS_X86_64 1
 #endif
 #if defined(__aarch64__) || defined(_M_ARM64)
 #define IS_ARM64 1
 #endif
+
 
 // this is almost standard?
 #undef STRINGIFY_IMPLEMENTATION_
@@ -79,6 +81,7 @@
 #endif
 
 namespace simdjson {
+
 // portable version of  posix_memalign
 static inline void *aligned_malloc(size_t alignment, size_t size) {
   void *p;

--- a/include/simdjson/simdjson.h
+++ b/include/simdjson/simdjson.h
@@ -41,7 +41,8 @@ enum ErrorValues {
   EMPTY,           // no structural document found
   UNESCAPED_CHARS, // found unescaped characters in a string.
   UNCLOSED_STRING, // missing quote at the end
-  UNEXPECTED_ERROR // indicative of a bug in simdjson
+  UNEXPECTED_ERROR, // indicative of a bug in simdjson
+  WINDOW_ERROR, // window is too small?
 };
 const std::string &error_message(const int);
 } // namespace simdjson

--- a/include/simdjson/stage2_build_tape.h
+++ b/include/simdjson/stage2_build_tape.h
@@ -19,6 +19,28 @@ int unified_machine(const char *buf, size_t len, ParsedJson &pj) {
 }
 
 
+// more flexible version
+
+// This structure is ugly and at least partly unnecessary, it should go away?
+// We need to track the current depth, but not much else?
+typedef struct {
+  uint32_t current_depth;
+  size_t current_index;
+} stage2_status;
+
+template <Architecture T = Architecture::NATIVE>
+WARN_UNUSED  int
+unified_machine_init(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s);
+
+template <Architecture T = Architecture::NATIVE>
+WARN_UNUSED  int
+unified_machine_continue(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index);
+
+template <Architecture T = Architecture::NATIVE>
+WARN_UNUSED  int
+unified_machine_finish(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s);
+
+
 
 // Streaming
 template <Architecture T = Architecture::NATIVE>

--- a/include/simdjson/stage2_build_tape.h
+++ b/include/simdjson/stage2_build_tape.h
@@ -21,24 +21,23 @@ int unified_machine(const char *buf, size_t len, ParsedJson &pj) {
 
 // more flexible version
 
-// This structure is ugly and at least partly unnecessary, it should go away?
-// We need to track the current depth, but not much else?
-typedef struct {
-  uint32_t current_depth;
-  size_t current_index;
-} stage2_status;
+
+/**
+* The unified_machine_init, unified_machine_continue and unified_machine_finish
+* functions are meant to support interruptible and interleaved processing.
+*/
 
 template <Architecture T = Architecture::NATIVE>
 WARN_UNUSED  int
-unified_machine_init(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s);
+unified_machine_init(const uint8_t *buf, size_t len, ParsedJson &pj);
 
 template <Architecture T = Architecture::NATIVE>
 WARN_UNUSED  int
-unified_machine_continue(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index);
+unified_machine_continue(const uint8_t *buf, size_t len, ParsedJson &pj, size_t last_index);
 
 template <Architecture T = Architecture::NATIVE>
 WARN_UNUSED  int
-unified_machine_finish(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s);
+unified_machine_finish(const uint8_t *buf, size_t len, ParsedJson &pj);
 
 
 

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -30,22 +30,27 @@ unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson 
     return arm64::unified_machine(buf, len, pj, next_json);
 }
 
+/**
+* The unified_machine_init, unified_machine_continue and unified_machine_finish
+* functions are meant to support interruptible and interleaved processing.
+*/
+
 template <>
 WARN_UNUSED  int
-unified_machine_init<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s) {
-    return arm64::unified_machine_init(buf, len, pj, s);
+unified_machine_init<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj) {
+    return arm64::unified_machine_init(buf, len, pj);
 }
 
 template <>
 WARN_UNUSED  int
-unified_machine_continue<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index) {
-    return arm64::unified_machine_continue(buf, len, pj, s, last_index);
+unified_machine_continue<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t last_index) {
+    return arm64::unified_machine_continue(buf, len, pj,last_index);
 }
 
 template <>
 WARN_UNUSED  int
-unified_machine_finish<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
-    return arm64::unified_machine_continue(buf, len, pj, s, pj.n_structural_indexes);
+unified_machine_finish<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj) {
+    return arm64::unified_machine_continue(buf, len, pj, pj.n_structural_indexes);
 }
 
 

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -21,12 +21,7 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  arm64::stage2_status status;
-  int ret = arm64::unified_machine_init(buf, len, pj, status);
-  if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = arm64::unified_machine_continue<false>(buf, len, pj, status, pj.n_structural_indexes);
-  }
-  return ret;
+  return arm64::unified_machine(buf, len, pj);
 }
 
 template <>
@@ -44,13 +39,13 @@ unified_machine_init<Architecture::ARM64>(const uint8_t *buf, size_t len, Parsed
 template <>
 WARN_UNUSED  int
 unified_machine_continue<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index) {
-    return arm64::unified_machine_continue<true>(buf, len, pj, s, last_index);
+    return arm64::unified_machine_continue(buf, len, pj, s, last_index);
 }
 
 template <>
 WARN_UNUSED  int
 unified_machine_finish<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
-    return arm64::unified_machine_continue<true>(buf, len, pj, s, pj.n_structural_indexes);
+    return arm64::unified_machine_continue(buf, len, pj, s, pj.n_structural_indexes);
 }
 
 

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -24,7 +24,7 @@ unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson 
   arm64::stage2_status status;
   int ret = arm64::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = arm64::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
+    ret = arm64::unified_machine_continue<arm64::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;
 }

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -21,7 +21,12 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  return arm64::unified_machine(buf, len, pj);
+  arm64::stage2_status status;
+  int ret = arm64::unified_machine_init(buf, len, pj, status);
+  while(ret == simdjson::SUCCESS_AND_HAS_MORE) {
+    ret = arm64::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
+  }
+  return ret;
 }
 
 template <>

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -24,7 +24,7 @@ unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson 
   arm64::stage2_status status;
   int ret = arm64::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = arm64::unified_machine_continue<arm64::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
+    ret = arm64::unified_machine_continue<false>(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;
 }
@@ -50,7 +50,7 @@ unified_machine_continue<Architecture::ARM64>(const uint8_t *buf, size_t len, Pa
 template <>
 WARN_UNUSED  int
 unified_machine_finish<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
-    return arm64::unified_machine_continue<false>(buf, len, pj, s, pj.n_structural_indexes);
+    return arm64::unified_machine_continue<true>(buf, len, pj, s, pj.n_structural_indexes);
 }
 
 

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -35,6 +35,27 @@ unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson 
     return arm64::unified_machine(buf, len, pj, next_json);
 }
 
+template <>
+WARN_UNUSED  int
+unified_machine_init<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s) {
+    return arm64::unified_machine_init(buf, len, pj, s);
+}
+
+template <>
+WARN_UNUSED  int
+unified_machine_continue<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index) {
+    return arm64::unified_machine_continue<true>(buf, len, pj, s, last_index);
+}
+
+template <>
+WARN_UNUSED  int
+unified_machine_finish<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
+    return arm64::unified_machine_continue<false>(buf, len, pj, s, pj.n_structural_indexes);
+}
+
+
+
+
 } // namespace simdjson
 
 #endif // IS_ARM64

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -23,7 +23,7 @@ WARN_UNUSED int
 unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj) {
   arm64::stage2_status status;
   int ret = arm64::unified_machine_init(buf, len, pj, status);
-  while(ret == simdjson::SUCCESS_AND_HAS_MORE) {
+  if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
     ret = arm64::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;

--- a/src/generic/stage2_build_tape.h
+++ b/src/generic/stage2_build_tape.h
@@ -25,8 +25,8 @@
 #define SET_GOTO_START_CONTINUE_AT(d) {pj.ret_address[d] = &&start_continue;}
 #define GOTO_CONTINUE() {goto *pj.ret_address[depth];}
 #else
-#define SET_GOTO_ARRAY_CONTINUE() {pj.ret_address[depth] = true;}
-#define SET_GOTO_OBJECT_CONTINUE() {pj.ret_address[depth] = false;}
+#define SET_GOTO_ARRAY_CONTINUE() {pj.ret_address[depth] = 'a';}
+#define SET_GOTO_OBJECT_CONTINUE() {pj.ret_address[depth] = 'o';}
 #define SET_GOTO_START_CONTINUE() {pj.ret_address[depth] = 's';}
 #define SET_GOTO_START_CONTINUE_AT(d) {pj.ret_address[d] = 's';}
 
@@ -35,7 +35,7 @@
     if (pj.ret_address[depth] == 'o') {                                        \
       goto object_continue;                                                    \
     } else if (pj.ret_address[depth] == 'a') {                                 \
-      goto object_continue;                                                    \
+      goto array_continue;                                                    \
     } else {                                                                   \
       goto start_continue;                                                     \
     }                                                                          \
@@ -454,7 +454,6 @@ main_array_switch:
   default:
     goto fail;
   }
-
 array_continue:
   UPDATE_CHAR();
   switch (c) {
@@ -1015,7 +1014,6 @@ main_array_switch:
   default:
     goto fail;
   }
-
 array_continue:
   UPDATE_CHAR();
   // Next bit could be a switch case. Short switch cases tend to be compiled

--- a/src/generic/stage2_build_tape.h
+++ b/src/generic/stage2_build_tape.h
@@ -48,7 +48,7 @@ enum {
 
 typedef struct {
   uint32_t current_depth;
-  uint32_t current_index;
+  size_t current_index;
 } stage2_status;
 
  /**
@@ -65,7 +65,7 @@ unified_machine_init(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_stat
     pj.error_code = simdjson::CAPACITY;
     return pj.error_code;
   }
-  uint32_t i = 0;
+  size_t i = 0;
   uint32_t idx; 
   uint8_t c;
   /*//////////////////////////// START STATE /////////////////////////////
@@ -276,7 +276,7 @@ unified_machine_continue(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_
   uint8_t c;    /* used to track the (structural) character we are looking at,
                    updated */
   uint32_t depth = s.current_depth;
-  uint32_t i = s.current_index;/* index of the structural character (0,1,2,3...) */
+  size_t i = s.current_index;/* index of the structural character (0,1,2,3...) */
   UPDATE_CHAR();
   // next switch case is executed once.
   switch (c) {

--- a/src/generic/stage2_build_tape.h
+++ b/src/generic/stage2_build_tape.h
@@ -82,7 +82,7 @@ unified_machine_init(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_stat
     goto fail;
   }
   // we are now going to check whether we have a single atom
-  UPDATE_CHAR()
+  UPDATE_CHAR();
   switch (c) {
   case '{':
   case '[':

--- a/src/generic/stage2_build_tape.h
+++ b/src/generic/stage2_build_tape.h
@@ -408,6 +408,7 @@ object_continue:
   // as sequences of branches. The compiler can't tell which branch is more likely
   // but we *know* that most objects contain more than one entry so that ',' is a common result,
   // hence we build our own sequence of branches, starting with the most likely result.
+  // This may or may not help: revisit at will.
   if( c == ',' ) {// common case
     UPDATE_CHAR();
     if( c == '"' ) { // common case
@@ -545,6 +546,7 @@ array_continue:
   // as sequences of branches. The compiler can't tell which branch is more likely
   // but we *know* that most arrays contain more than one entry so that ',' is a common result,
   // hence we build our own sequence of branches, starting with the most likely result.
+  // This may or may not help: revisit at will.
   if(c == ',') {
     UPDATE_CHAR();
     goto main_array_switch;

--- a/src/generic/stage2_streaming_build_tape.h
+++ b/src/generic/stage2_streaming_build_tape.h
@@ -14,7 +14,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
 
     /*//////////////////////////// START STATE /////////////////////////////
      */
-    SET_GOTO_START_CONTINUE()
+    SET_GOTO_START_CONTINUE();
     pj.containing_scope_offset[depth] = pj.get_current_loc();
     pj.write_tape(0, 'r'); /* r for root, 0 is going to get overwritten */
     /* the root is used, if nothing else, to capture the size of the tape */
@@ -254,7 +254,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
             pj.write_tape(0, c); /* here the compilers knows what c is so this gets
                             optimized */
             /* we have not yet encountered } so we need to come back for it */
-            SET_GOTO_OBJECT_CONTINUE()
+            SET_GOTO_OBJECT_CONTINUE();
             /* we found an object inside an object, so we need to increment the
              * depth                                                             */
             depth++;
@@ -269,7 +269,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
             pj.write_tape(0, c); /* here the compilers knows what c is so this gets
                             optimized */
             /* we have not yet encountered } so we need to come back for it */
-            SET_GOTO_OBJECT_CONTINUE()
+            SET_GOTO_OBJECT_CONTINUE();
             /* we found an array inside an object, so we need to increment the depth
              */
             depth++;
@@ -374,7 +374,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
             pj.containing_scope_offset[depth] = pj.get_current_loc();
             pj.write_tape(0, c); /* here the compilers knows what c is so this gets
                             optimized */
-            SET_GOTO_ARRAY_CONTINUE()
+            SET_GOTO_ARRAY_CONTINUE();
             /* we found an object inside an array, so we need to increment the depth
              */
             depth++;
@@ -389,7 +389,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
             pj.containing_scope_offset[depth] = pj.get_current_loc();
             pj.write_tape(0, c); /* here the compilers knows what c is so this gets
                             optimized */
-            SET_GOTO_ARRAY_CONTINUE()
+            SET_GOTO_ARRAY_CONTINUE();
             /* we found an array inside an array, so we need to increment the depth
              */
             depth++;

--- a/src/generic/stage2_streaming_build_tape.h
+++ b/src/generic/stage2_streaming_build_tape.h
@@ -29,6 +29,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
     switch (c) {
         case '{':
             pj.containing_scope_offset[depth] = pj.get_current_loc();
+            SET_GOTO_START_CONTINUE();
             depth++;
             if (depth >= pj.depth_capacity) {
                 goto fail;
@@ -38,6 +39,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
             goto object_begin;
         case '[':
             pj.containing_scope_offset[depth] = pj.get_current_loc();
+            SET_GOTO_START_CONTINUE();
             depth++;
             if (depth >= pj.depth_capacity) {
                 goto fail;

--- a/src/generic/stage2_streaming_build_tape.h
+++ b/src/generic/stage2_streaming_build_tape.h
@@ -14,7 +14,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
 
     /*//////////////////////////// START STATE /////////////////////////////
      */
-    //SET_GOTO_START_CONTINUE()
+    SET_GOTO_START_CONTINUE()
     pj.containing_scope_offset[depth] = pj.get_current_loc();
     pj.write_tape(0, 'r'); /* r for root, 0 is going to get overwritten */
     /* the root is used, if nothing else, to capture the size of the tape */
@@ -169,7 +169,7 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
         default:
             goto fail;
     }
-    //start_continue:
+    start_continue:
     /* the string might not be NULL terminated. */
     if (i + 1 == pj.n_structural_indexes && buf[idx+2] == '\0') {
         goto succeed;
@@ -307,15 +307,6 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
     pj.write_tape(pj.containing_scope_offset[depth], c);
     pj.annotate_previous_loc(pj.containing_scope_offset[depth],
                              pj.get_current_loc());
-    if(depth == 1) {
-      if (i + 1 == pj.n_structural_indexes && buf[idx+2] == '\0') {
-        goto succeed;
-      } else if(depth == 1 && i<=pj.n_structural_indexes) {
-        goto succeedAndHasMore;
-      } else {
-        goto fail;
-      }
-    }
     /* goto saved_state */
     GOTO_CONTINUE()
 
@@ -408,7 +399,6 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
         default:
             goto fail;
     }
-
     array_continue:
     UPDATE_CHAR();
     switch (c) {

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -24,7 +24,7 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  haswell::stage2_status status;
+  stage2_status status;
   int ret = haswell::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
     ret = haswell::unified_machine_continue<haswell::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
@@ -37,6 +37,29 @@ WARN_UNUSED int
 unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
     return haswell::unified_machine(buf, len, pj, next_json);
 }
+
+
+
+template <>
+WARN_UNUSED  int
+unified_machine_init<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s) {
+    return haswell::unified_machine_init(buf, len, pj, s);
+}
+
+template <>
+WARN_UNUSED  int
+unified_machine_continue<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index) {
+    return haswell::unified_machine_continue<true>(buf, len, pj, s, last_index);
+}
+
+template <>
+WARN_UNUSED  int
+unified_machine_finish<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
+    return haswell::unified_machine_continue<false>(buf, len, pj, s, pj.n_structural_indexes);
+}
+
+
+
 
 } // namespace simdjson
 UNTARGET_REGION

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -27,7 +27,7 @@ unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJso
   stage2_status status;
   int ret = haswell::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = haswell::unified_machine_continue<haswell::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
+    ret = haswell::unified_machine_continue<false>(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;
 }
@@ -55,7 +55,7 @@ unified_machine_continue<Architecture::HASWELL>(const uint8_t *buf, size_t len, 
 template <>
 WARN_UNUSED  int
 unified_machine_finish<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
-    return haswell::unified_machine_continue<false>(buf, len, pj, s, pj.n_structural_indexes);
+    return haswell::unified_machine_continue<true>(buf, len, pj, s, pj.n_structural_indexes);
 }
 
 

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -26,7 +26,7 @@ WARN_UNUSED int
 unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj) {
   haswell::stage2_status status;
   int ret = haswell::unified_machine_init(buf, len, pj, status);
-  while(ret == simdjson::SUCCESS_AND_HAS_MORE) {
+  if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
     ret = haswell::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -24,12 +24,7 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  stage2_status status;
-  int ret = haswell::unified_machine_init(buf, len, pj, status);
-  if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = haswell::unified_machine_continue<false>(buf, len, pj, status, pj.n_structural_indexes);
-  }
-  return ret;
+  return haswell::unified_machine(buf, len, pj);
 }
 
 template <>
@@ -42,20 +37,20 @@ unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJso
 
 template <>
 WARN_UNUSED  int
-unified_machine_init<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s) {
-    return haswell::unified_machine_init(buf, len, pj, s);
+unified_machine_init<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj) {
+    return haswell::unified_machine_init(buf, len, pj);
 }
 
 template <>
 WARN_UNUSED  int
-unified_machine_continue<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index) {
-    return haswell::unified_machine_continue<true>(buf, len, pj, s, last_index);
+unified_machine_continue<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t last_index) {
+    return haswell::unified_machine_continue(buf, len, pj, last_index);
 }
 
 template <>
 WARN_UNUSED  int
-unified_machine_finish<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
-    return haswell::unified_machine_continue<true>(buf, len, pj, s, pj.n_structural_indexes);
+unified_machine_finish<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj) {
+    return haswell::unified_machine_continue(buf, len, pj, pj.n_structural_indexes);
 }
 
 

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -33,7 +33,10 @@ unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJso
     return haswell::unified_machine(buf, len, pj, next_json);
 }
 
-
+/**
+* The unified_machine_init, unified_machine_continue and unified_machine_finish
+* functions are meant to support interruptible and interleaved processing.
+*/
 
 template <>
 WARN_UNUSED  int

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -27,7 +27,7 @@ unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJso
   haswell::stage2_status status;
   int ret = haswell::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = haswell::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
+    ret = haswell::unified_machine_continue<haswell::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;
 }

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -24,7 +24,12 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  return haswell::unified_machine(buf, len, pj);
+  haswell::stage2_status status;
+  int ret = haswell::unified_machine_init(buf, len, pj, status);
+  while(ret == simdjson::SUCCESS_AND_HAS_MORE) {
+    ret = haswell::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
+  }
+  return ret;
 }
 
 template <>

--- a/src/parsedjson.cpp
+++ b/src/parsedjson.cpp
@@ -90,7 +90,7 @@ bool ParsedJson::allocate_capacity(size_t len, size_t max_depth) {
 #ifdef SIMDJSON_USE_COMPUTED_GOTO
   ret_address = new (std::nothrow) void *[max_depth];
 #else
-  ret_address = new (std::nothrow) char[max_depth];
+  ret_address = new (std::nothrow) bool[max_depth];
 #endif
   if ((string_buf == nullptr) || (tape == nullptr) ||
       (containing_scope_offset == nullptr) || (ret_address == nullptr) ||

--- a/src/parsedjson.cpp
+++ b/src/parsedjson.cpp
@@ -90,7 +90,7 @@ bool ParsedJson::allocate_capacity(size_t len, size_t max_depth) {
 #ifdef SIMDJSON_USE_COMPUTED_GOTO
   ret_address = new (std::nothrow) void *[max_depth];
 #else
-  ret_address = new (std::nothrow) bool[max_depth];
+  ret_address = new (std::nothrow) char[max_depth];
 #endif
   if ((string_buf == nullptr) || (tape == nullptr) ||
       (containing_scope_offset == nullptr) || (ret_address == nullptr) ||

--- a/src/parsedjson.cpp
+++ b/src/parsedjson.cpp
@@ -16,7 +16,7 @@ ParsedJson::ParsedJson(ParsedJson &&p)
       structural_indexes(p.structural_indexes), tape(p.tape),
       containing_scope_offset(p.containing_scope_offset),
       ret_address(p.ret_address), string_buf(p.string_buf),
-      current_string_buf_loc(p.current_string_buf_loc), valid(p.valid) {
+      current_string_buf_loc(p.current_string_buf_loc), valid(p.valid), current_depth(p.current_depth) {
   p.structural_indexes = nullptr;
   p.tape = nullptr;
   p.containing_scope_offset = nullptr;

--- a/src/simdjson.cpp
+++ b/src/simdjson.cpp
@@ -24,6 +24,7 @@ const std::map<int, const std::string> error_strings = {
     {UNCLOSED_STRING, "A string is opened, but never closed."},
     {UNEXPECTED_ERROR, "Unexpected error, consider reporting this problem as "
                        "you may have found a bug in simdjson"},
+    {WINDOW_ERROR, "Your window might be too small"}
 };
 
 // string returned when the error code is not recognized

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -27,7 +27,7 @@ unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJs
   westmere::stage2_status status;
   int ret = westmere::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = westmere::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
+    ret = westmere::unified_machine_continue<westmere::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;
 }

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -27,7 +27,7 @@ unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJs
   stage2_status status;
   int ret = westmere::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = westmere::unified_machine_continue<westmere::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
+    ret = westmere::unified_machine_continue<false>(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;
 }
@@ -53,7 +53,7 @@ unified_machine_continue<Architecture::WESTMERE>(const uint8_t *buf, size_t len,
 template <>
 WARN_UNUSED  int
 unified_machine_finish<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
-    return westmere::unified_machine_continue<false>(buf, len, pj, s, pj.n_structural_indexes);
+    return westmere::unified_machine_continue<true>(buf, len, pj, s, pj.n_structural_indexes);
 }
 
 

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -24,12 +24,7 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  stage2_status status;
-  int ret = westmere::unified_machine_init(buf, len, pj, status);
-  if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
-    ret = westmere::unified_machine_continue<false>(buf, len, pj, status, pj.n_structural_indexes);
-  }
-  return ret;
+  return westmere::unified_machine(buf, len, pj);
 }
 
 template <>
@@ -38,22 +33,27 @@ unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJs
     return westmere::unified_machine(buf, len, pj, next_json);
 }
 
+/**
+* The unified_machine_init, unified_machine_continue and unified_machine_finish
+* functions are meant to support interruptible and interleaved processing.
+*/
+
 template <>
 WARN_UNUSED  int
-unified_machine_init<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s) {
-    return westmere::unified_machine_init(buf, len, pj, s);
+unified_machine_init<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj) {
+    return westmere::unified_machine_init(buf, len, pj);
 }
 
 template <>
 WARN_UNUSED  int
-unified_machine_continue<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index) {
-    return westmere::unified_machine_continue<true>(buf, len, pj, s, last_index);
+unified_machine_continue<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t last_index) {
+    return westmere::unified_machine_continue(buf, len, pj, last_index);
 }
 
 template <>
 WARN_UNUSED  int
-unified_machine_finish<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
-    return westmere::unified_machine_continue<true>(buf, len, pj, s, pj.n_structural_indexes);
+unified_machine_finish<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj) {
+    return westmere::unified_machine_continue(buf, len, pj, pj.n_structural_indexes);
 }
 
 

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -26,7 +26,7 @@ WARN_UNUSED int
 unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj) {
   westmere::stage2_status status;
   int ret = westmere::unified_machine_init(buf, len, pj, status);
-  while(ret == simdjson::SUCCESS_AND_HAS_MORE) {
+  if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
     ret = westmere::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
   }
   return ret;

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -24,7 +24,7 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  westmere::stage2_status status;
+  stage2_status status;
   int ret = westmere::unified_machine_init(buf, len, pj, status);
   if(ret == simdjson::SUCCESS_AND_HAS_MORE) {
     ret = westmere::unified_machine_continue<westmere::check_index_end_false>(buf, len, pj, status, pj.n_structural_indexes);
@@ -37,6 +37,26 @@ WARN_UNUSED int
 unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
     return westmere::unified_machine(buf, len, pj, next_json);
 }
+
+template <>
+WARN_UNUSED  int
+unified_machine_init<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status& s) {
+    return westmere::unified_machine_init(buf, len, pj, s);
+}
+
+template <>
+WARN_UNUSED  int
+unified_machine_continue<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s, size_t last_index) {
+    return westmere::unified_machine_continue<true>(buf, len, pj, s, last_index);
+}
+
+template <>
+WARN_UNUSED  int
+unified_machine_finish<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, stage2_status &s) {
+    return westmere::unified_machine_continue<false>(buf, len, pj, s, pj.n_structural_indexes);
+}
+
+
 
 
 } // namespace simdjson

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -24,7 +24,12 @@ namespace simdjson {
 template <>
 WARN_UNUSED int
 unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj) {
-  return westmere::unified_machine(buf, len, pj);
+  westmere::stage2_status status;
+  int ret = westmere::unified_machine_init(buf, len, pj, status);
+  while(ret == simdjson::SUCCESS_AND_HAS_MORE) {
+    ret = westmere::unified_machine_continue(buf, len, pj, status, pj.n_structural_indexes);
+  }
+  return ret;
 }
 
 template <>

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -96,9 +96,8 @@ bool validate(const char *dirname) {
         printf("size of file in bytes: %zu \n", p.size());
         everything_fine = false;
       }
-
       const int interleaved_parse_res = interleaved_json_parse(p, pj, 4096);
-      printf("%s (interleaved)", parse_res == 0 ? "ok" : "invalid");
+      printf("\t%s (interleaved)", parse_res == 0 ? "ok" : "invalid");
       if (contains("EXCLUDE", name)) {
         // skipping
         how_many--;

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -96,8 +96,14 @@ bool validate(const char *dirname) {
         printf("size of file in bytes: %zu \n", p.size());
         everything_fine = false;
       }
+#ifdef SIMDJSON_THREADS_ENABLED // ugly hack, todo: fixme
+      simdjson::ParsedJson pj_threaded;
+      const int interleaved_parse_res = interleaved_json_parse(p, pj, pj_threaded, 4096);
+#else
       const int interleaved_parse_res = interleaved_json_parse(p, pj, 4096);
+#endif
       printf("\t%s (interleaved)", parse_res == 0 ? "ok" : "invalid");
+
       if (contains("EXCLUDE", name)) {
         // skipping
         how_many--;

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -80,7 +80,7 @@ bool validate(const char *dirname) {
       }
       ++how_many;
       const int parse_res = json_parse(p, pj);
-      printf("%s\n", parse_res == 0 ? "ok" : "invalid");
+      printf("%s", parse_res == 0 ? "ok" : "invalid");
       if (contains("EXCLUDE", name)) {
         // skipping
         how_many--;
@@ -96,6 +96,25 @@ bool validate(const char *dirname) {
         printf("size of file in bytes: %zu \n", p.size());
         everything_fine = false;
       }
+
+      const int interleaved_parse_res = interleaved_json_parse(p, pj, 4096);
+      printf("%s (interleaved)", parse_res == 0 ? "ok" : "invalid");
+      if (contains("EXCLUDE", name)) {
+        // skipping
+        how_many--;
+      } else if (starts_with("pass", name) && interleaved_parse_res != 0) {
+        is_file_as_expected[i] = false;
+        printf("warning: file %s should pass but it fails. Error is: %s\n",
+               name, simdjson::error_message(interleaved_parse_res).data());
+        printf("size of file in bytes: %zu \n", p.size());
+        everything_fine = false;
+      } else if (starts_with("fail", name) && interleaved_parse_res == 0) {
+        is_file_as_expected[i] = false;
+        printf("warning: file %s should fail but it passes.\n", name);
+        printf("size of file in bytes: %zu \n", p.size());
+        everything_fine = false;
+      }
+      printf("\n");
       free(fullpath);
     }
   }


### PR DESCRIPTION
Currently stage 2 is mostly a bulky function. Moreover, it can only process a whole JSON document (or nothing).

In PR https://github.com/lemire/simdjson/pull/406, it was rewritten using a functions and an object-oriented approach, but with a significant performance penalty.

This new PR tries to simplify stage 2 and add the ability to process only part of a JSON document with (theoretically) the ability to resume parsing the rest of the document.

There are many applications of such an approach. One is parallelization as in PR https://github.com/lemire/simdjson/pull/406, another one is to do away with the need for whole string padding.

The idea here is that you can stop parsing before the beginning of an array or an object. So there are only two states to keep track off... either you are at the start of the array or at the start of an object.

This PR has a small performance penalty. However, it may be a penalty that we are willing to pay for the improved flexibility.

This PR is deliberately minimalist: instead of doing massive changes, I try to change as little as possible.

Comments are invited.

cc @jkeiser @piotte13 @pauldreik 