### PR TITLE
Fix #420

### DIFF
--- a/include/simdjson/parsedjsoniterator.h
+++ b/include/simdjson/parsedjsoniterator.h
@@ -331,6 +331,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_key(const char *key) {
           return true;
         }
       } while (next());
+      up();
     }
     return false;
 }
@@ -346,6 +347,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_key_insensitive(
           return true;
         }
       } while (next());
+      up();
     }
     return false;
 }
@@ -362,6 +364,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_key(const char *key,
         return true;
       }
     } while (next());
+    up();
   }
   return false;
 }
@@ -378,6 +381,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_index(uint32_t index) {
     if (i == index) {
       return true;
     }
+    up();
   }
   return false;
 }

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1246,6 +1246,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_key(const char *key) {
           return true;
         }
       } while (next());
+      up();
     }
     return false;
 }
@@ -1261,6 +1262,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_key_insensitive(
           return true;
         }
       } while (next());
+      up();
     }
     return false;
 }
@@ -1277,6 +1279,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_key(const char *key,
         return true;
       }
     } while (next());
+    up();
   }
   return false;
 }
@@ -1293,6 +1296,7 @@ bool ParsedJson::BasicIterator<max_depth>::move_to_index(uint32_t index) {
     if (i == index) {
       return true;
     }
+    up();
   }
   return false;
 }


### PR DESCRIPTION
Fix #420 

According to the documentation, `move_to_key()` and `move_to_index()` should go back to the original depth if the desired key is not found.
