### PR TITLE
[WIP] Store structural bits instead of indices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ LIBHEADERS=src/jsoncharutils.h src/simdprune_tables.h $(LIBHEADERS_GENERIC) $(LI
 PUBHEADERS=include/simdjson/common_defs.h include/simdjson/isadetection.h include/simdjson/jsonformatutils.h include/simdjson/jsonioutil.h include/simdjson/jsonminifier.h include/simdjson/jsonparser.h include/simdjson/padded_string.h include/simdjson/parsedjson.h include/simdjson/parsedjsoniterator.h include/simdjson/portability.h include/simdjson/simdjson.h include/simdjson/simdjson_version.h include/simdjson/stage1_find_marks.h include/simdjson/stage2_build_tape.h
 HEADERS=$(PUBHEADERS) $(LIBHEADERS)
 
-LIBFILES=src/jsonioutil.cpp src/jsonparser.cpp src/jsonstream.cpp src/simdjson.cpp src/stage1_find_marks.cpp src/stage2_build_tape.cpp src/parsedjson.cpp src/parsedjsoniterator.cpp
+LIBFILES=src/jsonioutil.cpp src/jsonparser.cpp src/simdjson.cpp src/stage1_find_marks.cpp src/stage2_build_tape.cpp src/parsedjson.cpp src/parsedjsoniterator.cpp
 MINIFIERHEADERS=include/simdjson/jsonminifier.h
 MINIFIERLIBFILES=src/jsonminifier.cpp
 

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -62,7 +62,10 @@ stat_t simdjson_compute_stats(const simdjson::padded_string &p) {
   answer.true_count = 0;
   answer.false_count = 0;
   answer.string_count = 0;
-  answer.structural_indexes_count = pj.n_structural_indexes;
+  answer.structural_indexes_count = 0;
+  for (size_t block=0; block<ROUNDUP_N(block.size(), 64); block++) {
+    answer.structural_indexes_count += hamming(pj.structurals[block]);
+  }
   size_t tape_idx = 0;
   uint64_t tape_val = pj.tape[tape_idx++];
   uint8_t type = (tape_val >> 56);

--- a/include/simdjson/jsonstream.h
+++ b/include/simdjson/jsonstream.h
@@ -120,7 +120,7 @@ namespace simdjson {
         const char *_buf;
         size_t _len;
         size_t _batch_size;
-        size_t next_json{0};
+        size_t block{0};
         bool error_on_last_attempt{false};
         bool load_next_batch{true};
         size_t current_buffer_loc{0};

--- a/include/simdjson/parsedjson.h
+++ b/include/simdjson/parsedjson.h
@@ -111,9 +111,8 @@ public:
   size_t tape_capacity{0};
   size_t string_capacity{0};
   uint32_t current_loc{0};
-  uint32_t n_structural_indexes{0};
-
-  uint32_t *structural_indexes;
+  size_t num_structural_blocks{0};
+  uint64_t *structural_blocks;
 
   uint64_t *tape;
   uint32_t *containing_scope_offset;

--- a/jsonexamples/small/demo.json
+++ b/jsonexamples/small/demo.json
@@ -1,15 +1,16 @@
 {
-        "Image": {
-            "Width":  800,
-            "Height": 600,
-            "Title":  "View from 15th Floor",
-            "Thumbnail": {
-                "Url":    "http://www.example.com/image/481989943",
-                "Height": 125,
-                "Width":  100
-            },
-            "Animated" : false,
-            "IDs": [116, 943, 234, 38793]
-          }
-      }
+    "Imageasgkljghadfkjghasdfkjgasgkljghadfkjghasdfkjgasgkljghadfkjghasdfkjgasgkljghadfkjghasdfkj": {
+        "Width":  800,
+        "Height": 600,
+        "Title":  "View from 15th Floor",
+        "Thumbnail": {
+            "Url":    "http://www.example.com/image/481989943abcdefghijabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghiabcdefghijjjjjjjjjjjjjjjjj",
+            "Height": 125,
+            "Width":  100
+        },
+        "Animated" : false,
+        "IDs": [116, 943, 234, 38793]
+    }
+}
+
 

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -10483,7 +10483,7 @@ bool ParsedJson::allocate_capacity(size_t len, size_t max_depth) {
   valid = false;
   byte_capacity = 0; // will only set it to len after allocations are a success
   n_structural_indexes = 0;
-  uint32_t max_structures = ROUNDUP_N(len, 64) + 2 + 7;
+  uint32_t max_structures = (ROUNDUP_N(len, 64)/64) + 2 + 7;
   structural_indexes = new (std::nothrow) uint32_t[max_structures];
   // a pathological input like "[[[[..." would generate len tape elements, so
   // need a capacity of at least len + 1, but it is also possible to do

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -12,7 +12,7 @@
 namespace simdjson::arm64 {
 
 #include "generic/stage2_build_tape.h"
-#include "generic/stage2_streaming_build_tape.h"
+// #include "generic/stage2_streaming_build_tape.h"
 
 } // namespace simdjson::arm64
 
@@ -24,11 +24,11 @@ unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson 
   return arm64::unified_machine(buf, len, pj);
 }
 
-template <>
-WARN_UNUSED int
-unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
-    return arm64::unified_machine(buf, len, pj, next_json);
-}
+// template <>
+// WARN_UNUSED int
+// unified_machine<Architecture::ARM64>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
+//     return arm64::unified_machine(buf, len, pj, next_json);
+// }
 
 } // namespace simdjson
 

--- a/src/generic/stage2_streaming_build_tape.h
+++ b/src/generic/stage2_streaming_build_tape.h
@@ -177,9 +177,9 @@ unified_machine(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_jso
     }
     start_continue:
     /* the string might not be NULL terminated. */
-    if (i + 1 == pj.n_structural_indexes && buf[idx+2] == '\0') {
+    if (AT_EOF() && buf[idx+2] == '\0') {
         goto succeed;
-    } else if(depth == 1 && i<=pj.n_structural_indexes) {
+    } else if(depth == 1 && !AT_EOF()) {
         goto succeedAndHasMore;
     } else {
         goto fail;

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -13,7 +13,7 @@ TARGET_HASWELL
 namespace simdjson::haswell {
 
 #include "generic/stage2_build_tape.h"
-#include "generic/stage2_streaming_build_tape.h"
+// #include "generic/stage2_streaming_build_tape.h"
 
 } // namespace simdjson::haswell
 UNTARGET_REGION
@@ -27,11 +27,11 @@ unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJso
   return haswell::unified_machine(buf, len, pj);
 }
 
-template <>
-WARN_UNUSED int
-unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
-    return haswell::unified_machine(buf, len, pj, next_json);
-}
+// template <>
+// WARN_UNUSED int
+// unified_machine<Architecture::HASWELL>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
+//     return haswell::unified_machine(buf, len, pj, next_json);
+// }
 
 } // namespace simdjson
 UNTARGET_REGION

--- a/src/parsedjson.cpp
+++ b/src/parsedjson.cpp
@@ -70,7 +70,7 @@ bool ParsedJson::allocate_capacity(size_t len, size_t max_depth) {
   deallocate();
   valid = false;
   byte_capacity = 0; // will only set it to len after allocations are a success
-  size_t structural_blocks_capacity = (len / 64 + 1);
+  size_t structural_blocks_capacity = (len / 64 + 2);
   structural_blocks = new (std::nothrow) uint64_t[structural_blocks_capacity];
   // a pathological input like "[[[[..." would generate len tape elements, so
   // need a capacity of at least len + 1, but it is also possible to do

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -13,7 +13,7 @@ TARGET_WESTMERE
 namespace simdjson::westmere {
 
 #include "generic/stage2_build_tape.h"
-#include "generic/stage2_streaming_build_tape.h"
+// #include "generic/stage2_streaming_build_tape.h"
 
 } // namespace simdjson::westmere
 UNTARGET_REGION
@@ -27,11 +27,11 @@ unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJs
   return westmere::unified_machine(buf, len, pj);
 }
 
-template <>
-WARN_UNUSED int
-unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
-    return westmere::unified_machine(buf, len, pj, next_json);
-}
+// template <>
+// WARN_UNUSED int
+// unified_machine<Architecture::WESTMERE>(const uint8_t *buf, size_t len, ParsedJson &pj, size_t &next_json) {
+//     return westmere::unified_machine(buf, len, pj, next_json);
+// }
 
 
 } // namespace simdjson


### PR DESCRIPTION
This code moves the structural indexing from stage 1 to stage 2, on the theory that stage 2 already has a loop that runs once per structural so this is less taxing there. At the moment the combined stages run about 15-20% slower; thus "engineering research."

1. **Stage 1:** Stores only structural bits in stage 1, removing the highly branchy index gathering.
2. **Stage 2:** Gathers one index per ADVANCE in stage 2. (This is now done with functions instead of #defines--trying to remove those where it makes sense.)
3. **Empty Blocks**: We do *not* store empty masks for 64-byte blocks devoid of structural characters, so that stage 2 can be assured of having a bit to process on every iteration. To compensate for this, stage 2 detects when these 64-bit "blank spots" happen in the three places they can happen:
   - spaces: if the document contains one or more 64-byte blocks full of spaces (or the tail of a number/string/literal plus spaces filling a block), the next offset will always land on a space. This should be exceedingly rare. Each time we read a structural, we check for spaces, increment the offset by 64, and retry. (ED.: now that I say this out loud, I'm pretty sure it's not true. If a block consists of 62 string characters, an end quote, and a space, the block will have no structurals, but the next block may have a structural that lands on a string character, which could be anything. Posting anyway, because (a) some of the todos may fix it, and (b) even negative results have useful learnings.)
   - strings: if a string contains one or more 64-byte blocks, we adjust the offset after parsing the string.
   - numbers: if a number contains one or more 64-byte blocks filled with digits/signifiers, we adjust the offset after parsing the number. (NOTE: we don't actually do this yet. it's a TODO.)
4. **Strings:** we return the end offset of the string so the caller can adjust the offset.

Further experiments:
- [ ] Write out the base index of each block in stage 1, and don't do any compensation in stage 2
- [ ] Write out 0-structural masks in stage 2, and amortize the cost somehow
  - [ ] Adjust structural offsets based on the end index of each value before doing any space adjustments
  - [ ] Write out an "structural end character mask" along with 0-structural masks (and maybe "special characters" like \ for string and . and e for numbers) in an "end structural mask".
- [ ] Move UTF8 validation to the string tape, to see if it improves stage 1 enough to compensate (theory being that a 100% branchless stage 1 will have disproportionate benefits).
- [ ] Do string and number index adjustment inside the string parsing algorithm, possibly changing the algorithm to run on block boundaries to match up better.
- [ ] Don't have two stages: pass the structurals list directly on to stage 2 for each block / series of blocks.