### PR TITLE
Instead of emulating the whole parsing as stage 1 + stage 2, let us benchmark the real thing.

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -303,27 +303,35 @@ struct benchmarker {
       exit_error(string("Failed to parse ") + filename + " during stage 1: " + pj.get_error_message());
     }
 
-    // Stage 2 (unified machine)
-    event_count stage2_count;
-    if (!stage1_only || stats == NULL) {
-      if (!stage1_only) {
-        collector.start();
-      }
+    // Stage 2 (unified machine) and the rest
+
+    if (stage1_only) {
+      all_stages << stage1_count;
+    } else {
+      event_count stage2_count;
+      collector.start();
       result = parser.stage2((const uint8_t *)json.data(), json.size(), pj);
-      if (!stage1_only) {
-        stage2_count = collector.end();
-        stage2 << stage2_count;
-      }
-
+      stage2_count = collector.end();
+      stage2 << stage2_count;
+      // You would think that the entire processing is just stage 1 + stage 2, but
+      // empirically, that's not true! Not even close to be true in some instances.
+      event_count allstages_count;
+      collector.start();
+      result = parser.parse((const uint8_t *)json.data(), json.size(), pj);
       if (result != simdjson::SUCCESS) {
-        exit_error(string("Failed to parse ") + filename + " during stage 2: " + pj.get_error_message());
+        exit_error(string("Failed to parse ") + filename + " during overall parsing " + pj.get_error_message());
       }
+      allstages_count = collector.end();
+      all_stages << allstages_count;
     }
-
-    all_stages << (stage1_count + stage2_count);
-
     // Calculate stats the first time we parse
     if (stats == NULL) {
+      if (stage1_only) { //  we need stage 2 once
+        result = parser.stage2((const uint8_t *)json.data(), json.size(), pj);
+        if (result != simdjson::SUCCESS) {
+          printf("Warning: failed to parse during stage 2. Unable to acquire statistics.\n");
+        }
+      }
       stats = new json_stats(json, pj);
     }
   }

--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -456,9 +456,9 @@ struct benchmarker {
               printf("|- Stage 2\n");
       print_aggregate("|    ", stage2.best);
       if (collector.has_events()) {
-        double freq1 = (stage1.cycles() / stage1.elapsed_sec()) / 1000000000.0;
-        double freq2 = (stage2.cycles() / stage2.elapsed_sec()) / 1000000000.0;
-        double freqall = (all_stages.cycles() / all_stages.elapsed_sec()) / 1000000000.0;
+        double freq1 = (stage1.best.cycles() / stage1.best.elapsed_sec()) / 1000000000.0;
+        double freq2 = (stage2.best.cycles() / stage2.best.elapsed_sec()) / 1000000000.0;
+        double freqall = (all_stages.best.cycles() / all_stages.best.elapsed_sec()) / 1000000000.0;
         double freqmin = std::min(freq1, freq2);
         double freqmax = std::max(freq1, freq2);
         if((freqall < 0.95 * freqmin) or (freqall > 1.05 * freqmax)) {

--- a/benchmark/event_counter.h
+++ b/benchmark/event_counter.h
@@ -128,6 +128,7 @@ struct event_collector {
     return linux_events.is_working();
   }
 #else
+  event_collector() {}
   bool has_events() {
     return false;
   }

--- a/benchmark/json_parser.h
+++ b/benchmark/json_parser.h
@@ -133,6 +133,4 @@ struct json_parser {
   }
 };
 
-
-
 #endif

--- a/benchmark/json_parser.h
+++ b/benchmark/json_parser.h
@@ -43,6 +43,7 @@ using std::string;
 
 using stage2_functype = int(const uint8_t *buf, size_t len, ParsedJson &pj);
 using stage1_functype = int(const uint8_t *buf, size_t len, ParsedJson &pj);
+using jsonparse_functype = int(const uint8_t *buf, size_t len, ParsedJson &pj, bool streaming);
 
 stage1_functype* get_stage1_func(const Architecture architecture) {
   switch (architecture) {
@@ -83,31 +84,55 @@ stage2_functype* get_stage2_func(const Architecture architecture) {
   }
 }
 
+jsonparse_functype* get_jsonparse_func(const Architecture architecture) {
+  switch (architecture) {
+#ifdef IS_X86_64
+  case Architecture::HASWELL:
+    return &json_parse_implementation<Architecture::HASWELL>;
+    break;
+  case Architecture::WESTMERE:
+    return &json_parse_implementation<Architecture::WESTMERE>;
+    break;
+#endif
+#ifdef IS_ARM64
+  case Architecture::ARM64:
+    return &json_parse_implementation<Architecture::ARM64>;
+    break;
+#endif
+  default:
+    std::cerr << "The processor is not supported by simdjson." << std::endl;
+    exit(EXIT_FAILURE);
+  }
+}
+
 struct json_parser {
   const Architecture architecture;
   const stage1_functype *stage1_func;
   const stage2_functype *stage2_func;
+  const jsonparse_functype *jsonparse_func;
 
   json_parser(const Architecture _architecture) : architecture(_architecture) {
     this->stage1_func = get_stage1_func(architecture);
     this->stage2_func = get_stage2_func(architecture);
+    this->jsonparse_func = get_jsonparse_func(architecture);
   }
   json_parser() : json_parser(find_best_supported_architecture()) {}
 
   int stage1(const uint8_t *buf, const size_t len, ParsedJson &pj) const {
     return this->stage1_func(buf, len, pj);
   }
+
   int stage2(const uint8_t *buf, const size_t len, ParsedJson &pj) const {
     return this->stage2_func(buf, len, pj);
   }
 
   int parse(const uint8_t *buf, const size_t len, ParsedJson &pj) const {
-    int result = this->stage1(buf, len, pj);
-    if (result == SUCCESS) {
-      result = this->stage2(buf, len, pj);
-    }
-    return result;
+    // yes, you can construct jsonparse from stage 1 and stage 2,
+    // but why emulate it when we have the real thing?
+    return this->jsonparse_func(buf, len, pj, false);
   }
 };
+
+
 
 #endif

--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -68,10 +68,14 @@ void print_usage(ostream& out) {
   out << "-t         - Tabbed data output" << endl;
   out << "-v         - Verbose output." << endl;
   out << "-s STAGE   - Stop after the given stage." << endl;
-  out << "             -s stage1 - Stop after find_structural_bits." << endl;
-  out << "             -s all    - Run all stages." << endl;
+  out << "             -s stage1  - Stop after find_structural_bits." << endl;
+  out << "             -s all     - Run all stages." << endl;
+  out << "             -s allfast - Run all stages." << endl;
+
   out << "-a ARCH    - Use the parser with the designated architecture (HASWELL, WESTMERE" << endl;
   out << "             or ARM64). By default, detects best supported architecture." << endl;
+  out << "-o         - Estimate the overall speed as stage 1 + stage 2 instead of a rerun of both" << endl;
+
 }
 
 void exit_usage(string message) {
@@ -91,6 +95,7 @@ struct option_struct {
 
   bool verbose = false;
   bool tabbed_output = false;
+  bool rerunbothstages = true;
 
   option_struct(int argc, char **argv) {
     #ifndef _MSC_VER
@@ -121,6 +126,10 @@ struct option_struct {
             stage1_only = true;
           } else if (!strcmp(optarg, "all")) {
             stage1_only = false;
+            rerunbothstages = true; // for safety
+          } else if (!strcmp(optarg, "allfast")) {
+            stage1_only = false;
+            rerunbothstages = false;
           } else {
             exit_usage(string("Unsupported option value -s ") + optarg + ": expected -s stage1 or all");
           }
@@ -195,7 +204,7 @@ int main(int argc, char *argv[]) {
       // Benchmark each file once per iteration
       for (size_t f=0; f<options.files.size(); f++) {
         verbose() << "[verbose] " << benchmarkers[f]->filename << " iterations #" << iteration << "-" << (iteration+options.iteration_step-1) << endl;
-        benchmarkers[f]->run_iterations(options.iteration_step, true);
+        benchmarkers[f]->run_iterations(options.iteration_step, true, false);
       }
     }
   } else {
@@ -204,7 +213,7 @@ int main(int argc, char *argv[]) {
       // Benchmark each file once per iteration
       for (size_t f=0; f<options.files.size(); f++) {
         verbose() << "[verbose] " << benchmarkers[f]->filename << " iterations #" << iteration << "-" << (iteration+options.iteration_step-1) << endl;
-        benchmarkers[f]->run_iterations(options.iteration_step, false);
+        benchmarkers[f]->run_iterations(options.iteration_step, false, options.rerunbothstages);
       }
     }
   }


### PR DESCRIPTION
Amazingly, stage 2 alone can be slower than stage 1 and stage 2 together.

Look...

```
$ cd scripts/ruby
$ ruby kostya_large.rb
$ cd ..
$ cd ..
$ make parse
$ ./parse -n 10 scripts/1.json 
number of iterations 10 
                                                     
scripts/1.json
==============
  1742429 blocks -  111515519 bytes - 15728645 structurals ( 14.1 %)
special blocks with: utf8         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals   1742430 (100.0 %) - 8+ structurals   1716436 ( 98.5 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         0 (  0.0 %) - 8+ structurals     51988 (  3.0 %) - 16+ structurals         0 (  0.0 %)

All Stages
|    Speed        :  44.6178 ns per block ( 99.92%) -   0.6972 ns per byte -   4.9428 ns per structural -    1.434 GB/s
|    Cycles       : 164.5315 per block    ( 99.92%) -   2.5708 per byte    -  18.2269 per structural    -    3.688 GHz est. frequency
|    Instructions : 503.0693 per block    (100.00%) -   7.8605 per byte    -  55.7304 per structural    -    3.058 per cycle
|    Misses       : 1523128 branch misses ( 99.76%) - 11916639 cache misses ( 99.96%) - 16328392.00 cache references
|- Stage 1
|    Speed        :  22.0270 ns per block ( 49.33%) -   0.3442 ns per byte -   2.4402 ns per structural -    2.906 GB/s
|    Cycles       :  55.4957 per block    ( 33.70%) -   0.8671 per byte    -   6.1478 per structural    -    2.519 GHz est. frequency
|    Instructions : 171.7575 per block    ( 34.14%) -   2.6837 per byte    -  19.0274 per structural    -    3.095 per cycle
|    Misses       :  273409 branch misses ( 17.91%) - 2838304 cache misses ( 23.81%) - 3834943.00 cache references
|- Stage 2
|    Speed        :  48.8195 ns per block (109.33%) -   0.7628 ns per byte -   5.4083 ns per structural -    1.311 GB/s
|    Cycles       : 129.9075 per block    ( 78.89%) -   2.0298 per byte    -  14.3912 per structural    -    2.661 GHz est. frequency
|    Instructions : 331.3379 per block    ( 65.86%) -   5.1772 per byte    -  36.7058 per structural    -    2.551 per cycle
|    Misses       : 1308343 branch misses ( 85.69%) - 4440152 cache misses ( 37.24%) - 7016519.00 cache references
```