### PR TITLE
Find all escaped characters with fewer instructions

### DIFF
--- a/src/arm64/simd.h
+++ b/src/arm64/simd.h
@@ -107,7 +107,7 @@ namespace simdjson::arm64::simd {
     }
 
     // Store to array
-    really_inline void store(uint8_t dst[16]) { return vst1q_u8(dst, *this); }
+    really_inline void store(uint8_t dst[16]) const { return vst1q_u8(dst, *this); }
 
     // Saturated math
     really_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return vqaddq_u8(*this, other); }
@@ -207,7 +207,7 @@ namespace simdjson::arm64::simd {
     }
 
     // Store to array
-    really_inline void store(int8_t dst[16]) { return vst1q_s8(dst, *this); }
+    really_inline void store(int8_t dst[16]) const { return vst1q_s8(dst, *this); }
 
     // Explicit conversion to/from unsigned
     really_inline explicit simd8(const uint8x16_t other): simd8(vreinterpretq_s8_u8(other)) {}
@@ -265,7 +265,7 @@ namespace simdjson::arm64::simd {
     really_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1, const simd8<T> chunk2, const simd8<T> chunk3) : chunks{chunk0, chunk1, chunk2, chunk3} {}
     really_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+16), simd8<T>::load(ptr+32), simd8<T>::load(ptr+48)} {}
 
-    really_inline void store(T ptr[64]) {
+    really_inline void store(T ptr[64]) const {
       this->chunks[0].store(ptr+sizeof(simd8<T>)*0);
       this->chunks[1].store(ptr+sizeof(simd8<T>)*1);
       this->chunks[2].store(ptr+sizeof(simd8<T>)*2);


### PR DESCRIPTION
When simdjson searches for escaped quotes like `\"`, it produces a list of escaped non-backslash characters to rule out false positives like `\\\\"`. This patch redoes the algorithm to produce the full list of escapes (even though it's not needed), which turns out to improves performance.

It reduces stage 1 instructions by around 10%, and improves overall throughput by around 2% (and stage 1 by 7%), on Skylake. The speedup is largely achieved by focusing on `+`'s effect on the mask rather than the carry bit, removing the need for one of the two legs of the calculation (instead of both even and odd, we just do one `+`).

## Current Algorithm

The current algorithm uses `+` to find the end of a series of backslashes based on its start. To correct for series with an even number of backslashes, it does this twice: once for series that start on an even bit, and once for series that start on an odd bit. Then it masks out the ones that started on even bits and ended on even bits, and the same for odd -> odd, since that's the mark of an even number.

```markdown
| Operation                             | Mask          |
|---------------------------------------|---------------|
| Text                                  | "abc \\\" \\" |
| Even Bits                             | " b   \ " \ " |
| Backslash Mask                        |      \\\  \\  |
| End of Runs Starting At Even Bits (+) |             " |
| Even -> Odd (= odd # slashes)         |               |
| End of Runs Starting At Odd Bits (+)  |         "     |
| Odd -> Even (= even # slashes)        |         "     |
| Result                                |         "     |
```

It detects escapes leaking into the next block, with the overflow from the `+` on odd bit runs. The next block then pretends the first bit is not a backslash, and marks it as an escaped character.

## Updated Algorithm

The new algorithm essentially masks `101010101... on top of each series of backslashes to find real backslashes, and then shift it right to get the *escaped* characters. The trick is to do it without iterating (which leads to branches and performance doom). The basic idea is simple:

* **First,** mask `01010101` on top of the backslashes. This gets series that start on *odd* boundaries right (their first character will correctly have a 1), but series on *even* boundaries are exactly wrong (they need to be flipped).

* **Second,** isolate even-starting series using the addition trick.

* **Third,** XOR that into the result to flip the even bits to their correct value.

Bam! Shift that result and you have escaped characters.

```markdown
| Operation                      | Mask          |
|--------------------------------|---------------|
| Text                           | "abc \\\" \\" |
| Even Bits                      | " b   \ " \ " |
| Backslash Mask                 |      \\\  \\  |
| Runs Starting At Even Bits (+) |           \\  |
| Escapes For Odd Bit Runs       |      \ \   \  |
| Escapes (xor)                  |      \ \  \   |
| Result (shift)                 |       \ "  \  |
```

Overflow is the same as the previous algorithm, detecting when the first character of the next block is escaped with the overflow from the `+`. The next block pretends the first bit is not a backslash, and marks it as an escaped character.

NOTE: we could have done this the opposite way--mask `10101010` and flip odd series instead. Flipping even series allows us to use the overflow from the addition as overflow into the next block (since it puts carry bits after the odd series, which are the ones that can overflow). Waste not, want not :)

### Using the Add To Clear Bits

The same addition we use to find the end of a series, also *clears* the series: we're just concentrating on that use instead of the series end. Just to see an example:

```markdown
NOTE: numbers are written backwards from normal, so carries go left to right!

| Operation                      | Mask          |
|--------------------------------|---------------|
| Text                           | "abc \\\" \\" |
| Backslash Mask                 | 0000011100110 |
| Series Starts On Odd Bits      | 0000010000000 |
| +                              | 0000000010110 |
| As Mask                        |         " \\  |
```

Because we didn't try to add anything to the odd runs, they stayed around--and the even ones cleared away because of the carry! When you & this with the backslash mask, you get just the odd runs.