### PR TITLE
Making the project tag in simdjson more explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,15 @@
 cmake_minimum_required(VERSION 3.9) # CMP0069 NEW
+
+if (NOT CMAKE_BUILD_TYPE)
+                message(STATUS "No build type selected, default to Release")
+                set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+endif()
+
+project(simdjson 
+  DESCRIPTION "Parsing gigabytes of JSON per second" 
+  LANGUAGES CXX
+)
+
 include(CheckIPOSupported)
 check_ipo_supported(RESULT ltoresult)
 if(ltoresult)
@@ -14,12 +25,8 @@ set(CMAKE_MACOSX_RPATH OFF)
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
-if (NOT CMAKE_BUILD_TYPE)
-                message(STATUS "No build type selected, default to Release")
-                set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-endif()
 
-project(simdjson)
+
 set(SIMDJSON_LIB_NAME simdjson)
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,13 @@ project(simdjson
   LANGUAGES CXX
 )
 
-include(CheckIPOSupported)
-check_ipo_supported(RESULT ltoresult)
-if(ltoresult)
-set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-endif()
+# LTO seems to create all sorts of fun problems. Let us
+# disable temporarily.
+#include(CheckIPOSupported)
+#check_ipo_supported(RESULT ltoresult)
+#if(ltoresult)
+#set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+#endif()
 
 # usage: cmake -DSIMDJSON_DISABLE_AVX=on ..
 option(SIMDJSON_DISABLE_AVX "Forcefully disable AVX even if hardware supports it" OFF)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,12 @@ if(MSVC)
 endif()
 
 add_cpp_test(basictests)
+if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+# next line is a workaround for an odr-violation in basictests regarding the globals 0x432a40 and 0x52045c under clang
+set_tests_properties(basictests PROPERTIES
+    ENVIRONMENT ASAN_OPTIONS="detect_odr_violation=0")
+endif()
+
 add_cpp_test(jsoncheck)
 add_cpp_test(jsonstream_test)
 add_cpp_test(pointercheck)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,11 +5,13 @@ if(MSVC)
 endif()
 
 add_cpp_test(basictests)
-if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+
+## Next bit should not be needed!
+#if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
 # next line is a workaround for an odr-violation in basictests regarding the globals 0x432a40 and 0x52045c under clang
-set_tests_properties(basictests PROPERTIES
-    ENVIRONMENT ASAN_OPTIONS="detect_odr_violation=0")
-endif()
+#set_tests_properties(basictests PROPERTIES
+#    ENVIRONMENT ASAN_OPTIONS="detect_odr_violation=0")
+#endif()
 
 add_cpp_test(jsoncheck)
 add_cpp_test(jsonstream_test)


### PR DESCRIPTION
@Lekensteyn  wrote

"LTO cannot be checked unless the language is specified with the
'project' option. "

Let us try to specify the language, then?

https://github.com/lemire/simdjson/pull/449