### PR TITLE
single header contains local includes in some CI's only

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -2,7 +2,7 @@
 #define SIMDJSON_COMMON_DEFS_H
 
 #include <cassert>
-#include "simdjson/portability.h"
+#include "portability.h"
 
 // we support documents up to 4GB
 #define SIMDJSON_MAXSIZE_BYTES 0xFFFFFFFF

--- a/include/simdjson/jsonioutil.h
+++ b/include/simdjson/jsonioutil.h
@@ -8,8 +8,8 @@
 #include <stdexcept>
 #include <string>
 
-#include "simdjson/common_defs.h"
-#include "simdjson/padded_string.h"
+#include "common_defs.h"
+#include "padded_string.h"
 
 namespace simdjson {
 

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -1,7 +1,7 @@
 #ifndef SIMDJSON_PADDING_STRING_H
 #define SIMDJSON_PADDING_STRING_H
-#include "simdjson/portability.h"
-#include "simdjson/common_defs.h" // for SIMDJSON_PADDING
+#include "portability.h"
+#include "common_defs.h" // for SIMDJSON_PADDING
 
 #include <cstring>
 #include <memory>


### PR DESCRIPTION
wanted to sort out local includes inside "simdjson" with "simdjson/" in front .. then I noticed some CI's are complaining ... see the image below with the apparent cause...