### PR TITLE
Remove googletest entirely as benchmark dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,6 +31,3 @@
 [submodule "dependencies/benchmark"]
 	path = dependencies/benchmark
 	url = https://github.com/google/benchmark.git
-[submodule "dependencies/googletest"]
-	path = dependencies/googletest
-	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,20 +63,16 @@ add_subdirectory(benchmark)
 
 option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" OFF)
 if (SIMDJSON_GOOGLE_BENCHMARKS)
-  set(BENCHMARK_ENABLE_GTEST_TESTS OFF)
-  if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/googletest/CMakeLists.txt)
-    # message(STATUS "Unable to find ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/googletest/CMakeLists.txt")
-    execute_process(COMMAND git submodule update --init -- ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/googletest
+  if(NOT EXISTS dependencies/benchmark/CMakeLists.txt)
+    # message(STATUS "Unable to find dependencies/benchmark/CMakeLists.txt")
+    execute_process(COMMAND git submodule update --init -- dependencies/benchmark
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
-  if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/benchmark/CMakeLists.txt)
-    # message(STATUS "Unable to find ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/benchmark/CMakeLists.txt")
-    execute_process(COMMAND git submodule update --init -- ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/benchmark
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-  endif()
-
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dependencies/googletest)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/dependencies/benchmark)
+  option(BENCHMARK_ENABLE_TESTING OFF)
+  set(BENCHMARK_ENABLE_TESTING OFF)
+  option(BENCHMARK_ENABLE_INSTALL OFF)
+  set(BENCHMARK_ENABLE_INSTALL OFF)
+  add_subdirectory(dependencies/benchmark)
 endif()
 
 # for fuzzing, read the comments in the fuzz/CMakeLists.txt file


### PR DESCRIPTION
This doesn't change the default of -DSIMDJSON_GOOGLE_BENCHMARKS=OFF, but it does disable all building of the Google Benchmark tests, bringing compile time back down to normal. It also removes the dependencies/googletest submodule.

At this point, the only real extra time taken is in `cmake`--an extra 8 seconds to detect features the first time it's run. `make` is a couple seconds longer purely because it is building the actual `bench_parse_call` executable. Since cmake is off the main dev path, we probably could enable it without hurting our experience after this.