### PR TITLE
Rename invalid_json to simdjson_error

### DIFF
--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -30,7 +30,7 @@ static void parser_parse_exception(State& state) {
   for (auto _ : state) {
     try {
       UNUSED document &doc = parser.parse(EMPTY_ARRAY);
-    } catch(invalid_json &j) {
+    } catch(simdjson_error &j) {
       return;
     }
   }
@@ -55,7 +55,7 @@ static void document_parse_exception(State& state) {
   for (auto _ : state) {
     try {
       UNUSED document doc = document::parse(EMPTY_ARRAY);
-    } catch(invalid_json &j) {
+    } catch(simdjson_error &j) {
       return;
     }
   }

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -83,14 +83,14 @@ public:
    * Read the root element of this document as a JSON array.
    *
    * @return The JSON array.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not an array
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not an array
    */
   operator array() const noexcept(false);
   /**
    * Read this element as a JSON object (key/value pairs).
    *
    * @return The JSON object.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not an object
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not an object
    */
   operator object() const noexcept(false);
 
@@ -239,7 +239,7 @@ public:
    * Return the document, or throw an exception if it is invalid.
    *
    * @return the document.
-   * @exception invalid_json if the document is invalid or there was an error parsing it.
+   * @exception simdjson_error if the document is invalid or there was an error parsing it.
    */
   operator document() noexcept(false);
 
@@ -298,7 +298,7 @@ public:
    * A reference to the document, or throw an exception if it is invalid.
    *
    * @return the document.
-   * @exception invalid_json if the document is invalid or there was an error parsing it.
+   * @exception simdjson_error if the document is invalid or there was an error parsing it.
    */
   operator document&() noexcept(false);
 
@@ -449,7 +449,7 @@ public:
    * Read this element as a boolean.
    *
    * @return The boolean value
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not a boolean.
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not a boolean.
    */
   inline operator bool() const noexcept(false);
 
@@ -460,7 +460,7 @@ public:
    * an actual string.
    *
    * @return The string value.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not a string.
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not a string.
    */
   inline explicit operator const char*() const noexcept(false);
 
@@ -471,7 +471,7 @@ public:
    * an actual string.
    *
    * @return The string value.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not a string.
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not a string.
    */
   inline operator std::string_view() const noexcept(false);
 
@@ -479,38 +479,38 @@ public:
    * Read this element as an unsigned integer.
    *
    * @return The integer value.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not an integer
-   * @exception invalid_json(NUMBER_OUT_OF_RANGE) if the integer doesn't fit in 64 bits or is negative
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not an integer
+   * @exception simdjson_error(NUMBER_OUT_OF_RANGE) if the integer doesn't fit in 64 bits or is negative
    */
   inline operator uint64_t() const noexcept(false);
   /**
    * Read this element as an signed integer.
    *
    * @return The integer value.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not an integer
-   * @exception invalid_json(NUMBER_OUT_OF_RANGE) if the integer doesn't fit in 64 bits
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not an integer
+   * @exception simdjson_error(NUMBER_OUT_OF_RANGE) if the integer doesn't fit in 64 bits
    */
   inline operator int64_t() const noexcept(false);
   /**
    * Read this element as an double.
    *
    * @return The double value.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not a number
-   * @exception invalid_json(NUMBER_OUT_OF_RANGE) if the integer doesn't fit in 64 bits or is negative
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not a number
+   * @exception simdjson_error(NUMBER_OUT_OF_RANGE) if the integer doesn't fit in 64 bits or is negative
    */
   inline operator double() const noexcept(false);
   /**
    * Read this element as a JSON array.
    *
    * @return The JSON array.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not an array
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not an array
    */
   inline operator document::array() const noexcept(false);
   /**
    * Read this element as a JSON object (key/value pairs).
    *
    * @return The JSON object.
-   * @exception invalid_json(UNEXPECTED_TYPE) if the JSON element is not an object
+   * @exception simdjson_error(UNEXPECTED_TYPE) if the JSON element is not an object
    */
   inline operator document::object() const noexcept(false);
 
@@ -1187,7 +1187,7 @@ public:
 
   // type aliases for backcompat
   using Iterator = document::iterator;
-  using InvalidJSON = invalid_json;
+  using InvalidJSON = simdjson_error;
 
   // Next location to write to in the tape
   uint32_t current_loc{0};

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -52,12 +52,12 @@ inline std::ostream& operator<<(std::ostream& out, error_code error) noexcept;
 /**
  * Exception thrown when an exception-supporting simdjson method is called
  */
-struct invalid_json : public std::exception {
+struct simdjson_error : public std::exception {
   /**
    * Create an exception from a simdjson error code.
    * @param error The error code
    */
-  invalid_json(error_code error) noexcept : _error{error} { }
+  simdjson_error(error_code error) noexcept : _error{error} { }
   /** The error message */
   const char *what() const noexcept { return error_message(error()); }
   error_code error() const noexcept { return _error; }

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -20,32 +20,32 @@ template<typename T>
 inline document::element_result<T>::element_result(error_code _error) noexcept : value(), error{_error} {}
 template<>
 inline document::element_result<std::string_view>::operator std::string_view() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 template<>
 inline document::element_result<const char *>::operator const char *() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 template<>
 inline document::element_result<bool>::operator bool() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 template<>
 inline document::element_result<uint64_t>::operator uint64_t() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 template<>
 inline document::element_result<int64_t>::operator int64_t() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 template<>
 inline document::element_result<double>::operator double() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 
@@ -55,15 +55,15 @@ inline document::element_result<double>::operator double() const noexcept(false)
 inline document::element_result<document::array>::element_result(document::array _value) noexcept : value(_value), error{SUCCESS} {}
 inline document::element_result<document::array>::element_result(error_code _error) noexcept : value(), error{_error} {}
 inline document::element_result<document::array>::operator document::array() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 inline document::array::iterator document::element_result<document::array>::begin() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value.begin();
 }
 inline document::array::iterator document::element_result<document::array>::end() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value.end();
 }
 
@@ -73,7 +73,7 @@ inline document::array::iterator document::element_result<document::array>::end(
 inline document::element_result<document::object>::element_result(document::object _value) noexcept : value(_value), error{SUCCESS} {}
 inline document::element_result<document::object>::element_result(error_code _error) noexcept : value(), error{_error} {}
 inline document::element_result<document::object>::operator document::object() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value;
 }
 inline document::element_result<document::element> document::element_result<document::object>::operator[](const std::string_view &key) const noexcept {
@@ -85,11 +85,11 @@ inline document::element_result<document::element> document::element_result<docu
   return value[key];
 }
 inline document::object::iterator document::element_result<document::object>::begin() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value.begin();
 }
 inline document::object::iterator document::element_result<document::object>::end() const noexcept(false) {
-  if (error) { throw invalid_json(error); }
+  if (error) { throw simdjson_error(error); }
   return value.end();
 }
 
@@ -441,7 +441,7 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
 inline document::doc_ref_result::doc_ref_result(document &_doc, error_code _error) noexcept : doc(_doc), error(_error) { }
 inline document::doc_ref_result::operator document&() noexcept(false) {
   if (error) {
-    throw invalid_json(error);
+    throw simdjson_error(error);
   }
   return doc;
 }
@@ -454,7 +454,7 @@ inline document::doc_result::doc_result(document &&_doc) noexcept : doc(std::mov
 inline document::doc_result::doc_result(error_code _error) noexcept : doc(), error(_error) { }
 inline document::doc_result::operator document() noexcept(false) {
   if (error) {
-    throw invalid_json(error);
+    throw simdjson_error(error);
   }
   return std::move(doc);
 }
@@ -473,7 +473,7 @@ inline bool document::parser::dump_raw_tape(std::ostream &os) const noexcept {
 }
 inline const document &document::parser::get_document() const noexcept(false) {
   if (!is_valid()) {
-    throw invalid_json(error);
+    throw simdjson_error(error);
   }
   return doc;
 }


### PR DESCRIPTION
We renamed InvalidJson to invalid_json to follow the snake_case rule ,,, but we're using this class for all errors in simdjson, including allocation and DOM navigation. simdjson_error better describes it. This is a straight search and replace.

This is backcompat safe, since we haven't actually released invalid_json (it's new in master since 0.2), so nobody can have a dependency with `try { } catch (invalid_json j) { }` 