### PR TITLE
Automatically allocate memory as needed in parse

### DIFF
--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -8,7 +8,7 @@ const padded_string EMPTY_ARRAY("[]", 2);
 
 static void json_parse(State& state) {
   document::parser parser;
-  if (!parser.allocate_capacity(EMPTY_ARRAY.length())) { return; }
+  if (parser.set_capacity(EMPTY_ARRAY.length())) { return; }
   for (auto _ : state) {
     auto error = simdjson::json_parse(EMPTY_ARRAY, parser);
     if (error) { return; }
@@ -17,7 +17,7 @@ static void json_parse(State& state) {
 BENCHMARK(json_parse);
 static void parser_parse_error_code(State& state) {
   document::parser parser;
-  if (!parser.allocate_capacity(EMPTY_ARRAY.length())) { return; }
+  if (parser.set_capacity(EMPTY_ARRAY.length())) { return; }
   for (auto _ : state) {
     auto [doc, error] = parser.parse(EMPTY_ARRAY);
     if (error) { return; }
@@ -26,7 +26,7 @@ static void parser_parse_error_code(State& state) {
 BENCHMARK(parser_parse_error_code);
 static void parser_parse_exception(State& state) {
   document::parser parser;
-  if (!parser.allocate_capacity(EMPTY_ARRAY.length())) { return; }
+  if (parser.set_capacity(EMPTY_ARRAY.length())) { return; }
   for (auto _ : state) {
     try {
       UNUSED document &doc = parser.parse(EMPTY_ARRAY);

--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -298,7 +298,7 @@ struct benchmarker {
     // Allocate document::parser
     collector.start();
     document::parser parser;
-    bool allocok = parser.allocate_capacity(json.size());
+    error_code error = parser.set_capacity(json.size());
     event_count allocate_count = collector.end();
     allocate_stage << allocate_count;
     // Run it once to get hot buffers
@@ -309,14 +309,14 @@ struct benchmarker {
       }
     }
 
-    if (!allocok) {
+    if (error) {
       exit_error(string("Unable to allocate_stage ") + to_string(json.size()) + " bytes for the JSON result.");
     }
     verbose() << "[verbose] allocated memory for parsed JSON " << endl;
 
     // Stage 1 (find structurals)
     collector.start();
-    error_code error = active_implementation->stage1((const uint8_t *)json.data(), json.size(), parser, false);
+    error = active_implementation->stage1((const uint8_t *)json.data(), json.size(), parser, false);
     event_count stage1_count = collector.end();
     stage1 << stage1_count;
     if (error) {

--- a/benchmark/parse_stream.cpp
+++ b/benchmark/parse_stream.cpp
@@ -39,9 +39,9 @@ int main (int argc, char *argv[]){
         for (auto i = 0; i < 3; i++) {
             //Actual test
             simdjson::document::parser parser;
-            bool allocok = parser.allocate_capacity(p.size());
-            if (!allocok) {
-                std::cerr << "failed to allocate memory" << std::endl;
+            simdjson::error_code alloc_error = parser.set_capacity(p.size());
+            if (alloc_error) {
+                std::cerr << alloc_error << std::endl;
                 return EXIT_FAILURE;
             }
             std::istringstream ss(std::string(p.data(), p.size()));

--- a/include/simdjson/implementation.h
+++ b/include/simdjson/implementation.h
@@ -45,7 +45,7 @@ public:
   virtual uint32_t required_instruction_sets() const { return _required_instruction_sets; };
 
   /**
-   * Run a full document parse (init_parse, stage1 and stage2).
+   * Run a full document parse (ensure_capacity, stage1 and stage2).
    *
    * Overridden by each implementation.
    *

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -148,21 +148,11 @@ really_inline bool document::stream::iterator::operator!=(const document::stream
 // threaded version of json_parse
 // todo: simplify this code further
 inline error_code document::stream::json_parse() noexcept {
-  // TODO we should bump the parser *anytime* capacity is less than batch size, not just 0.
-  if (unlikely(parser.capacity() == 0)) {
-    const bool allocok = parser.allocate_capacity(_batch_size);
-    if (!allocok) {
-      return simdjson::MEMALLOC;
-    }
-  } else if (unlikely(parser.capacity() < _batch_size)) {
-    return simdjson::CAPACITY;
-  }
-  if (unlikely(parser_thread.capacity() < _batch_size)) {
-    const bool allocok_thread = parser_thread.allocate_capacity(_batch_size);
-    if (!allocok_thread) {
-      return simdjson::MEMALLOC;
-    }
-  }
+  error = parser.ensure_capacity(_batch_size);
+  if (error) { return error; }
+  error = parser_thread.ensure_capacity(_batch_size);
+  if (error) { return error; }
+
   if (unlikely(load_next_batch)) {
     // First time loading
     if (!stage_1_thread.joinable()) {
@@ -240,14 +230,9 @@ inline error_code document::stream::json_parse() noexcept {
 
 // single-threaded version of json_parse
 inline error_code document::stream::json_parse() noexcept {
-  if (unlikely(parser.capacity() == 0)) {
-    const bool allocok = parser.allocate_capacity(_batch_size);
-    if (!allocok) {
-      return MEMALLOC;
-    }
-  } else if (unlikely(parser.capacity() < _batch_size)) {
-      return CAPACITY;
-  }
+  error = parser.ensure_capacity(_batch_size);
+  if (error) { return error; }
+
   if (unlikely(load_next_batch)) {
     advance(current_buffer_loc);
     n_bytes_parsed += current_buffer_loc;

--- a/include/simdjson/jsonparser.h
+++ b/include/simdjson/jsonparser.h
@@ -35,11 +35,6 @@ inline int json_parse(const padded_string &s, document::parser &parser) noexcept
 
 WARN_UNUSED static document::parser build_parsed_json(const uint8_t *buf, size_t len, bool realloc_if_needed = true) noexcept {
   document::parser parser;
-  if (!parser.allocate_capacity(len)) {
-    parser.valid = false;
-    parser.error = MEMALLOC;
-    return parser;
-  }
   json_parse(buf, len, parser, realloc_if_needed);
   return parser;
 }

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -33,10 +33,6 @@ inline uint64_t f64_ulp_dist(double a, double b) {
 bool number_test_small_integers() {
   char buf[1024];
   simdjson::document::parser parser;
-  if (!parser.allocate_capacity(1024)) {
-    printf("allocation failure in number_test_small_integers\n");
-    return false;
-  }
   for (int m = 10; m < 20; m++) {
     for (int i = -1024; i < 1024; i++) {
       auto n = sprintf(buf, "%*d", m, i);
@@ -71,10 +67,6 @@ bool number_test_small_integers() {
 bool number_test_powers_of_two() {
   char buf[1024];
   simdjson::document::parser parser;
-  if (!parser.allocate_capacity(1024)) {
-    printf("allocation failure in number_test\n");
-    return false;
-  }
   int maxulp = 0;
   for (int i = -1075; i < 1024; ++i) {// large negative values should be zero.
     double expected = pow(2, i);
@@ -138,10 +130,6 @@ bool number_test_powers_of_two() {
 bool number_test_powers_of_ten() {
   char buf[1024];
   simdjson::document::parser parser;
-  if (!parser.allocate_capacity(1024)) {
-    printf("allocation failure in number_test\n");
-    return false;
-  }
   for (int i = -1000000; i <= 308; ++i) {// large negative values should be zero.
     auto n = sprintf(buf,"1e%d", i);
     buf[n] = '\0';
@@ -247,12 +235,8 @@ bool stable_test() {
 static bool parse_json_message_issue467(char const* message, std::size_t len, size_t expectedcount) {
     simdjson::document::parser parser;
     size_t count = 0;
-    if (!parser.allocate_capacity(len)) {
-        std::cerr << "Failed to allocated memory for simdjson::document::parser" << std::endl;
-        return false;
-    }
     simdjson::padded_string str(message,len);
-    for (auto [doc, error] : parser.parse_many(str, parser.capacity())) {
+    for (auto [doc, error] : parser.parse_many(str, len)) {
       if (error) {
           std::cerr << "Failed with simdjson error= " << error << std::endl;
           return false;
@@ -639,10 +623,6 @@ bool skyprophet_test() {
       maxsize = s.size();
   }
   simdjson::document::parser parser;
-  if (!parser.allocate_capacity(maxsize)) {
-    printf("allocation failure in skyprophet_test\n");
-    return false;
-  }
   size_t counter = 0;
   for (auto &rec : data) {
     if ((counter % 10000) == 0) {

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -73,11 +73,6 @@ bool validate(const char *dirname) {
         return EXIT_FAILURE;
       }
       simdjson::ParsedJson pj;
-      bool allocok = pj.allocate_capacity(p.size(), 1024);
-      if (!allocok) {
-        std::cerr << "can't allocate memory" << std::endl;
-        return false;
-      }
       ++how_many;
       const int parse_res = json_parse(p, pj);
       printf("%s\n", parse_res == 0 ? "ok" : "invalid");

--- a/tests/numberparsingcheck.cpp
+++ b/tests/numberparsingcheck.cpp
@@ -180,11 +180,6 @@ bool validate(const char *dirname) {
       }
       // terrible hack but just to get it working
       simdjson::ParsedJson pj;
-      bool allocok = pj.allocate_capacity(p.size(), 1024);
-      if (!allocok) {
-        std::cerr << "can't allocate memory" << std::endl;
-        return false;
-      }
       float_count = 0;
       int_count = 0;
       invalid_count = 0;

--- a/tests/pointercheck.cpp
+++ b/tests/pointercheck.cpp
@@ -7,7 +7,6 @@ int main() {
   std::string json =
       "{\"/~01abc\": [0, {\"\\\\\\\" 0\": [\"value0\", \"value1\"]}]}";
   simdjson::ParsedJson pj;
-  assert(pj.allocate_capacity(json.length()));
   simdjson::json_parse(json.c_str(), json.length(), pj);
   assert(pj.is_valid());
   simdjson::ParsedJson::Iterator it(pj);

--- a/tests/singleheadertest.cpp
+++ b/tests/singleheadertest.cpp
@@ -10,9 +10,6 @@ int main() {
   if (!pj.is_valid()) {
     return EXIT_FAILURE;
   }
-  if (!pj.allocate_capacity(p.size())) {
-    return EXIT_FAILURE;
-  }
   const int res = json_parse(p, pj);
   if (res) {
     std::cerr << error_message(res) << std::endl;

--- a/tests/stringparsingcheck.cpp
+++ b/tests/stringparsingcheck.cpp
@@ -341,11 +341,6 @@ bool validate(const char *dirname) {
         return EXIT_FAILURE;
       }
       simdjson::ParsedJson pj;
-      bool allocok = pj.allocate_capacity(p.size(), 1024);
-      if (!allocok) {
-        std::cerr << "can't allocate memory" << std::endl;
-        return false;
-      }
       big_buffer = (char *)malloc(p.size());
       if (big_buffer == NULL) {
         std::cerr << "can't allocate memory" << std::endl;

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -80,11 +80,6 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
   simdjson::ParsedJson pj;
-  bool allocok = pj.allocate_capacity(p.size(), 1024);
-  if (!allocok) {
-    std::cerr << "failed to allocate memory" << std::endl;
-    return EXIT_FAILURE;
-  }
   int res =
       simdjson::json_parse(p, pj); // do the parsing, return false on error
   if (res != simdjson::SUCCESS) {

--- a/tools/jsonpointer.cpp
+++ b/tools/jsonpointer.cpp
@@ -59,11 +59,6 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
   simdjson::ParsedJson pj;
-  bool allocok = pj.allocate_capacity(p.size(), 1024);
-  if (!allocok) {
-    std::cerr << "failed to allocate memory" << std::endl;
-    return EXIT_FAILURE;
-  }
   int res =
       simdjson::json_parse(p, pj); // do the parsing, return false on error
   if (res) {


### PR DESCRIPTION
* Update parse() and parse_many() to automatically reallocate when encountering documents larger than capacity
* Add max_capacity so users can control or eliminate automatic reallocation
* Expose separate set_capacity() and set_max_depth() methods on parser

This is based on issue #517. Copy/pasting the reasoning and scenarios here:

In our current API, you have to decide on a maximum document size before you parse:

```c++
document::parser parser;
if (parser.allocate_capacity(1024)) { exit(1); }
const document &doc = parser.parse(json, json_len);
```

This is distracting for tutorials and is not ideal for use cases where the document size is unknown up front (e.g. servers). I propose we introduce automatic bumping of memory, up to a particular maximum.

With this proposal, you don't have to write down anything except "I have a parser and I want to parse my json":

```c++
document::parser parser;
const document &doc = parser.parse(json, json_len);
```

## Make The Right Way Easy

There's a principle I try to follow wherever possible when designing interfaces: *make the right way the easiest way; make the easiest way the right way.* Make it so people are using the software right as soon as they sit down, and don't encourage people to use it wrong by making the wrong way easier. It's never 100% possible, but it turns out you can really get pretty far down that road.

We want to encourage `parser` wherever possible because of its efficiency (and some nice API characteristics--if the user doesn't own the document, we don't have to worry about them destroying it before they're finished with it). Therefore we need it to be easy, and adding a decision for how much to allocate makes it harder than (for example) the less performant `document::parse`.

### document::parse

Even after this proposal, document::parse (formely build_parsed_json) is the easiest way to use simdjson. This is among several reasons we may want to remove it, but to do so we need to make parser.parse() as simple as possible first. We'll discuss removal / deprecation in a separate issue :)

## Server Use Case

When you're parsing a known set of documents, it's possible to choose this value in advance. If not, however--for example, in the case of a server--you have to do some dynamic checking:

```c++
document::parser parser;
parser.allocate_capacity(1024);
for (Request request : listen()) {
  if (request.body.length() > parser.capacity()) { parser.allocate_capacity(request.body.length()); }
  document doc = parser.parse(request.body);
  // ...
}
```

This is not optimal for a number of reasons. With this change, the pattern becomes:

```c++
document::parser parser;
for (Request request : listen()) {
  document doc = parser.parse(request.body);
  // ...
}
```

## Limiting Maximum Memory Usage

Some people will want to limit the maximum memory drain; we should give a maximum autobump in the constructor:

```c++
document::parser parser(1024*1024); // 1MB maximum
for (Request request : listen()) {
  auto [doc, error] = parser.parse(request.body);
  if (error == DOCUMENT_TOO_LARGE) { handle exceptional case ... }
  // ...
}
```

This should not prevent users from manually bumping above the autobump limit, so they can get existing behavior by specifying `document::parser parser(0);`.