### PR TITLE
Support cout << json

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,29 +144,28 @@ The simplest API to get started is `document::parse()`, which allocates a new pa
 ```c++
 auto [doc, error] = document::parse(string("[ 1, 2, 3 ]"));
 if (error) { cerr << "Error: " << error_message(error) << endl; exit(1); }
-doc.print_json(cout);
+cout << doc;
 ```
 
 If you're using exceptions, it gets even simpler (simdjson won't use exceptions internally, so you'll only pay the performance cost of exceptions in your own calling code):
 
 ```c++
 document doc = document::parse(string("[ 1, 2, 3 ]"));
-doc.print_json(cout);
+cout << doc;
 ```
 
 The simdjson library requires SIMDJSON_PADDING extra bytes at the end of a string (it doesn't matter if the bytes are initialized). The `padded_string` class is an easy way to ensure this is accomplished up front and prevent the extra allocation:
 
 ```c++
 document doc = document::parse(padded_string(string("[ 1, 2, 3 ]")));
-doc.print_json(cout);
+cout << doc;
 ```
 
 You can also load from a file with `parser.load()`:
 
 ```c++
 document::parser parser;
-document doc = parser.load(filename);
-doc.print_json(cout);
+cout << parser.load(filename);
 ```
 
 ### Reusing the parser for maximum efficiency
@@ -179,7 +178,7 @@ hot in cache and keeping allocation to a minimum.
 document::parser parser;
 for (padded_string json : { string("[1, 2, 3]"), string("true"), string("[ true, false ]") }) {
   document& doc = parser.parse(json);
-  doc.print_json(cout);
+  cout << doc;
 }
 ```
 
@@ -192,7 +191,7 @@ for (int i=0;i<argc;i++) {
   auto [doc, error] = parser.parse(get_corpus(argv[i]));
   if (error == CAPACITY) { cerr << "JSON files larger than 1MB are not supported!" << endl; exit(1); }
   if (error) { cerr << error << endl; exit(1); }
-  doc.print_json(cout);
+  cout << doc;
 }
 ```
 
@@ -208,7 +207,7 @@ for (int i=0;i<argc;i++) {
   auto [doc, error] = parser.parse(get_corpus(argv[i]));
   if (error == CAPACITY) { cerr << "JSON files larger than 1MB are not supported!" << endl; exit(1); }
   if (error) { cerr << error << endl; exit(1); }
-  doc.print_json(cout);
+  cout << doc;
 }
 ```
 

--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -1,5 +1,7 @@
 #include <benchmark/benchmark.h>
 #include "simdjson.h"
+#include <sstream>
+
 using namespace simdjson;
 using namespace benchmark;
 using namespace std;
@@ -228,5 +230,18 @@ static void iterator_twitter_image_sizes(State& state) {
   }
 }
 BENCHMARK(iterator_twitter_image_sizes);
+
+static void print_json(State& state) noexcept {
+  // Prints the number of results in twitter.json
+  padded_string json = get_corpus(JSON_TEST_PATH);
+  document::parser parser;
+  if (!parser.allocate_capacity(json.length())) { cerr << "allocation failed" << endl; return; }
+  if (int error = json_parse(json, parser); error != SUCCESS) { cerr << error_message(error) << endl; return; }
+  for (auto _ : state) {
+    std::stringstream s;
+    if (!parser.print_json(s)) { cerr << "print_json failed" << endl; return; }
+  }
+}
+BENCHMARK(print_json);
 
 BENCHMARK_MAIN();

--- a/include/simdjson/document_parser.h
+++ b/include/simdjson/document_parser.h
@@ -424,6 +424,7 @@ public:
   // print the json to std::ostream (should be valid)
   // return false if the tape is likely wrong (e.g., you did not parse a valid
   // JSON).
+  /** @deprecated Use cout << parser.parse() */
   inline bool print_json(std::ostream &os) const noexcept;
   inline bool dump_raw_tape(std::ostream &os) const noexcept;
 

--- a/include/simdjson/inline/document_iterator.h
+++ b/include/simdjson/inline/document_iterator.h
@@ -276,7 +276,7 @@ bool document_iterator<max_depth>::print(std::ostream &os, bool escape_strings) 
   case '"': // we have a string
     os << '"';
     if (escape_strings) {
-      internal::print_with_escapes(get_string(), os, get_string_length());
+      os << internal::escape_json_string(std::string_view(get_string(), get_string_length()));
     } else {
       // was: os << get_string();, but given that we can include null chars, we
       // have to do something crazier:

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <set>
 #include <string_view>
+#include <sstream>
 
 #include "simdjson.h"
 
@@ -242,39 +243,40 @@ UNUSED static void parse_many_stream_assign() {
 }
 
 static bool parse_json_message_issue467(char const* message, std::size_t len, size_t expectedcount) {
-    simdjson::document::parser parser;
-    size_t count = 0;
-    simdjson::padded_string str(message,len);
-    for (auto [doc, error] : parser.parse_many(str, len)) {
-      if (error) {
-          std::cerr << "Failed with simdjson error= " << error << std::endl;
-          return false;
-      }
-      count++;
-    }
-    if(count != expectedcount) {
-        std::cerr << "bad count" << std::endl;
+  simdjson::document::parser parser;
+  size_t count = 0;
+  simdjson::padded_string str(message,len);
+  for (auto [doc, error] : parser.parse_many(str, len)) {
+    if (error) {
+        std::cerr << "Failed with simdjson error= " << error << std::endl;
         return false;
     }
-    return true;
+    count++;
+  }
+  if(count != expectedcount) {
+      std::cerr << "bad count" << std::endl;
+      return false;
+  }
+  return true;
 }
 
 bool json_issue467() {
-    printf("Running json_issue467.\n");
-    const char * single_message = "{\"error\":[],\"result\":{\"token\":\"xxx\"}}";
-    const char* two_messages = "{\"error\":[],\"result\":{\"token\":\"xxx\"}}{\"error\":[],\"result\":{\"token\":\"xxx\"}}";
+  std::cout << "Running " << __func__ << std::endl;
+  const char * single_message = "{\"error\":[],\"result\":{\"token\":\"xxx\"}}";
+  const char* two_messages = "{\"error\":[],\"result\":{\"token\":\"xxx\"}}{\"error\":[],\"result\":{\"token\":\"xxx\"}}";
 
-    if(!parse_json_message_issue467(single_message, strlen(single_message),1)) {
-      return false;
-    }
-    if(!parse_json_message_issue467(two_messages, strlen(two_messages),2)) {
-      return false;
-    }
-    return true;
+  if(!parse_json_message_issue467(single_message, strlen(single_message),1)) {
+    return false;
+  }
+  if(!parse_json_message_issue467(two_messages, strlen(two_messages),2)) {
+    return false;
+  }
+  return true;
 }
 
 // returns true if successful
 bool navigate_test() {
+  std::cout << "Running " << __func__ << std::endl;
   std::string json = "{"
         "\"Image\": {"
             "\"Width\":  800,"
@@ -385,7 +387,7 @@ bool navigate_test() {
 
 // returns true if successful
 bool JsonStream_utf8_test() {
-  printf("Running JsonStream_utf8_test");
+  std::cout << "Running " << __func__ << std::endl;
   fflush(NULL);
   const size_t n_records = 10000;
   std::string data;
@@ -446,7 +448,7 @@ bool JsonStream_utf8_test() {
 
 // returns true if successful
 bool JsonStream_test() {
-  printf("Running JsonStream_test");
+  std::cout << "Running " << __func__ << std::endl;
   fflush(NULL);
   const size_t n_records = 10000;
   std::string data;
@@ -507,7 +509,7 @@ bool JsonStream_test() {
 
 // returns true if successful
 bool document_stream_test() {
-  printf("Running document_stream_test");
+  std::cout << "Running " << __func__ << std::endl;
   fflush(NULL);
   const size_t n_records = 10000;
   std::string data;
@@ -555,7 +557,7 @@ bool document_stream_test() {
 
 // returns true if successful
 bool document_stream_utf8_test() {
-  printf("Running document_stream_utf8_test");
+  std::cout << "Running " << __func__ << std::endl;
   fflush(NULL);
   const size_t n_records = 10000;
   std::string data;
@@ -603,6 +605,7 @@ bool document_stream_utf8_test() {
 
 // returns true if successful
 bool skyprophet_test() {
+  std::cout << "Running " << __func__ << std::endl;
   const size_t n_records = 100000;
   std::vector<std::string> data;
   char buf[1024];
@@ -658,6 +661,7 @@ namespace dom_api {
   using namespace std;
   using namespace simdjson;
   bool object_iterator() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "a": 1, "b": 2, "c": 3 })");
     const char* expected_key[] = { "a", "b", "c" };
     uint64_t expected_value[] = { 1, 2, 3 };
@@ -673,6 +677,7 @@ namespace dom_api {
   }
 
   bool array_iterator() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"([ 1, 10, 100 ])");
     uint64_t expected_value[] = { 1, 10, 100 };
     int i=0;
@@ -687,6 +692,7 @@ namespace dom_api {
   }
 
   bool object_iterator_empty() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"({})");
     int i = 0;
 
@@ -700,6 +706,7 @@ namespace dom_api {
   }
 
   bool array_iterator_empty() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"([])");
     int i=0;
 
@@ -713,6 +720,7 @@ namespace dom_api {
   }
 
   bool string_value() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"([ "hi", "has backslash\\" ])");
     document doc = document::parse(json);
     auto val = document::array(doc).begin();
@@ -725,6 +733,7 @@ namespace dom_api {
   }
 
   bool numeric_values() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"([ 0, 1, -1, 1.1 ])");
     document doc = document::parse(json);
     auto val = document::array(doc).begin();
@@ -744,6 +753,7 @@ namespace dom_api {
   }
 
   bool boolean_values() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"([ true, false ])");
     document doc = document::parse(json);
     auto val = document::array(doc).begin();
@@ -754,6 +764,7 @@ namespace dom_api {
   }
 
   bool null_value() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"([ null ])");
     document doc = document::parse(json);
     auto val = document::array(doc).begin();
@@ -762,6 +773,7 @@ namespace dom_api {
   }
 
   bool document_object_index() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "a": 1, "b": 2, "c": 3})");
     document doc = document::parse(json);
     if (uint64_t(doc["a"]) != 1) { cerr << "Expected uint64_t(doc[\"a\"]) to be 1, was " << uint64_t(doc["a"]) << endl; return false; }
@@ -778,6 +790,7 @@ namespace dom_api {
   }
 
   bool object_index() {
+    std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "obj": { "a": 1, "b": 2, "c": 3 } })");
     document doc = document::parse(json);
     if (uint64_t(doc["obj"]["a"]) != 1) { cerr << "Expected uint64_t(doc[\"obj\"][\"a\"]) to be 1, was " << uint64_t(doc["obj"]["a"]) << endl; return false; }
@@ -796,6 +809,7 @@ namespace dom_api {
   }
 
   bool twitter_count() {
+    std::cout << "Running " << __func__ << std::endl;
     // Prints the number of results in twitter.json
     document doc = document::load(JSON_TEST_PATH);
     uint64_t result_count = doc["search_metadata"]["count"];
@@ -804,6 +818,7 @@ namespace dom_api {
   }
 
   bool twitter_default_profile() {
+    std::cout << "Running " << __func__ << std::endl;
     // Print users with a default profile.
     set<string_view> default_users;
     document doc = document::load(JSON_TEST_PATH);
@@ -818,6 +833,7 @@ namespace dom_api {
   }
 
   bool twitter_image_sizes() {
+    std::cout << "Running " << __func__ << std::endl;
     // Print image names and sizes
     set<tuple<uint64_t, uint64_t>> image_sizes;
     document doc = document::load(JSON_TEST_PATH);
@@ -853,7 +869,197 @@ namespace dom_api {
   }
 }
 
+namespace format_tests {
+  using namespace simdjson;
+  using namespace std;
+  const padded_string DOCUMENT(string(R"({ "foo" : 1, "bar" : [ 1, 2, 3 ], "baz": { "a": 1, "b": 2, "c": 3 } })"));
+  const string MINIFIED(R"({"foo":1,"bar":[1,2,3],"baz":{"a":1,"b":2,"c":3}})");
+  bool assert_minified(ostringstream &actual, const std::string &expected=MINIFIED) {
+    if (actual.str() != expected) {
+      cerr << "Failed to correctly minify " << DOCUMENT.data() << endl;
+      cerr << "Expected: " << expected << endl;
+      cerr << "Actual:   " << actual.str() << endl;
+      return false;
+    }
+    return true;
+  }
+
+  bool print_document_parse() {
+    std::cout << "Running " << __func__ << std::endl;
+    ostringstream s;
+    s << document::parse(DOCUMENT);
+    return assert_minified(s);
+  }
+  bool print_minify_document_parse() {
+    std::cout << "Running " << __func__ << std::endl;
+    ostringstream s;
+    s << minify(document::parse(DOCUMENT));
+    return assert_minified(s);
+  }
+
+  bool print_parser_parse() {
+    std::cout << "Running " << __func__ << std::endl;
+    document::parser parser;
+    if (!parser.allocate_capacity(DOCUMENT.length())) { cerr << "Couldn't allocate!" << endl; return false; }
+    ostringstream s;
+    s << parser.parse(DOCUMENT);
+    return assert_minified(s);
+  }
+  bool print_minify_parser_parse() {
+    std::cout << "Running " << __func__ << std::endl;
+    document::parser parser;
+    if (!parser.allocate_capacity(DOCUMENT.length())) { cerr << "Couldn't allocate!" << endl; return false; }
+    ostringstream s;
+    s << minify(parser.parse(DOCUMENT));
+    return assert_minified(s);
+  }
+
+  bool print_document() {
+    std::cout << "Running " << __func__ << std::endl;
+    document doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << doc;
+    return assert_minified(s);
+  }
+  bool print_minify_document() {
+    std::cout << "Running " << __func__ << std::endl;
+    document doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << minify(doc);
+    return assert_minified(s);
+  }
+
+  bool print_document_ref() {
+    std::cout << "Running " << __func__ << std::endl;
+    document::parser parser;
+    if (!parser.allocate_capacity(DOCUMENT.length())) { cerr << "Couldn't allocate!" << endl; return false; }
+    const document &doc_ref = parser.parse(DOCUMENT);
+    ostringstream s;
+    s << doc_ref;
+    return assert_minified(s);
+  }
+  bool print_minify_document_ref() {
+    std::cout << "Running " << __func__ << std::endl;
+    document::parser parser;
+    if (!parser.allocate_capacity(DOCUMENT.length())) { cerr << "Couldn't allocate!" << endl; return false; }
+    const document &doc_ref = parser.parse(DOCUMENT);
+    ostringstream s;
+    s << minify(doc_ref);
+    return assert_minified(s);
+  }
+
+  bool print_element_result() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << doc["foo"];
+    return assert_minified(s, "1");
+  }
+  bool print_minify_element_result() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << minify(doc["foo"]);
+    return assert_minified(s, "1");
+  }
+
+  bool print_element() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    document::element value = doc["foo"];
+    ostringstream s;
+    s << value;
+    return assert_minified(s, "1");
+  }
+  bool print_minify_element() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    document::element value = doc["foo"];
+    ostringstream s;
+    s << minify(value);
+    return assert_minified(s, "1");
+  }
+
+  bool print_array_result() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << doc["bar"].as_array();
+    return assert_minified(s, "[1,2,3]");
+  }
+  bool print_minify_array_result() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << minify(doc["bar"].as_array());
+    return assert_minified(s, "[1,2,3]");
+  }
+
+  bool print_array() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    document::array value = doc["bar"];
+    ostringstream s;
+    s << value;
+    return assert_minified(s, "[1,2,3]");
+  }
+  bool print_minify_array() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    document::array value = doc["bar"];
+    ostringstream s;
+    s << minify(value);
+    return assert_minified(s, "[1,2,3]");
+  }
+
+  bool print_object_result() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << doc["baz"].as_object();
+    return assert_minified(s, R"({"a":1,"b":2,"c":3})");
+  }
+  bool print_minify_object_result() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    ostringstream s;
+    s << minify(doc["baz"].as_object());
+    return assert_minified(s, R"({"a":1,"b":2,"c":3})");
+  }
+
+  bool print_object() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    document::object value = doc["baz"];
+    ostringstream s;
+    s << value;
+    return assert_minified(s, R"({"a":1,"b":2,"c":3})");
+  }
+  bool print_minify_object() {
+    std::cout << "Running " << __func__ << std::endl;
+    const document &doc = document::parse(DOCUMENT);
+    document::object value = doc["baz"];
+    ostringstream s;
+    s << minify(value);
+    return assert_minified(s, R"({"a":1,"b":2,"c":3})");
+  }
+
+  bool run_tests() {
+    return print_document_parse() && print_minify_document_parse() &&
+           print_parser_parse() && print_minify_parser_parse() &&
+           print_document() && print_minify_document() &&
+           print_document_ref() && print_minify_document_ref() &&
+           print_element_result() && print_minify_element_result() &&
+           print_array_result() && print_minify_array_result() &&
+           print_object_result() && print_minify_object_result() &&
+           print_element() && print_minify_element() &&
+           print_array() && print_minify_array() &&
+           print_object() && print_minify_object();
+  }
+}
+
 bool error_messages_in_correct_order() {
+  std::cout << "Running " << __func__ << std::endl;
   using namespace simdjson;
   using namespace simdjson::internal;
   using namespace std;
@@ -894,6 +1100,8 @@ int main() {
   if (!skyprophet_test())
     return EXIT_FAILURE;
   if (!dom_api::run_tests())
+    return EXIT_FAILURE;
+  if (!format_tests::run_tests())
     return EXIT_FAILURE;
   if(!document_stream_test())
     return EXIT_FAILURE;

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -1076,6 +1076,21 @@ bool error_messages_in_correct_order() {
   return true;
 }
 
+bool lots_of_brackets() {
+  std::string input;
+  for(size_t i = 0; i < 1000; i++) {
+    input += "[";
+  }
+  for(size_t i = 0; i < 1000; i++) {
+    input += "]";
+  }
+  auto [doc, error] = simdjson::document::parse(input);
+  if (error) { std::cerr << "Error: " << simdjson::error_message(error) << std::endl; return false; }
+  std::cout << doc;
+  std::cout << std::endl;
+  return true;
+}
+
 int main() {
   // this is put here deliberately to check that the documentation is correct (README),
   // should this fail to compile, you should update the documentation:
@@ -1083,6 +1098,8 @@ int main() {
     printf("unsupported CPU\n"); 
   }
   std::cout << "Running basic tests." << std::endl;
+  if(!lots_of_brackets())
+    return EXIT_FAILURE;
   if(!json_issue467())
     return EXIT_FAILURE;
   if(!number_test_small_integers())

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -9,60 +9,61 @@ void document_parse_error_code() {
   string json("[ 1, 2, 3 ]");
   auto [doc, error] = document::parse(json);
   if (error) { cerr << "Error: " << error << endl; exit(1); }
-  if (!doc.print_json(cout)) { exit(1); }
-  cout << endl;
+  cout << doc << endl;
 }
 
 void document_parse_exception() {
   cout << __func__ << endl;
 
   string json("[ 1, 2, 3 ]");
-  document doc = document::parse(json);
-  if (!doc.print_json(cout)) { exit(1); }
-  cout << endl;
+  cout << document::parse(json) << endl;
 }
 
 void document_parse_padded_string() {
   cout << __func__ << endl;
 
   padded_string json(string("[ 1, 2, 3 ]"));
-  document doc = document::parse(json);
-  if (!doc.print_json(cout)) { exit(1); }
-  cout << endl;
+  cout << document::parse(json) << endl;
 }
 
 void document_parse_get_corpus() {
   cout << __func__ << endl;
 
-  auto json(get_corpus("jsonexamples/small/demo.json"));
-  document doc = document::parse(json);
-  if (!doc.print_json(cout)) { exit(1); }
-  cout << endl;
+  auto json = get_corpus("jsonexamples/small/demo.json");
+  cout << document::parse(json) << endl;
 }
 
 void document_load() {
   cout << __func__ << endl;
 
-  document doc = document::load("jsonexamples/small/demo.json");
-  if (!doc.print_json(cout)) { exit(1); }
-  cout << endl;
+  cout << document::load("jsonexamples/small/demo.json") << endl;
 }
 
-void parser_parse() {
+void parser_parse_error_code() {
   cout << __func__ << endl;
 
   // Allocate a parser big enough for all files
   document::parser parser;
-  simdjson::error_code capacity_error = parser.set_capacity(1024*1024);
-  if (capacity_error) { cerr << "Error setting capacity: " << capacity_error << endl; exit(1); }
 
   // Read files with the parser, one by one
   for (padded_string json : { string("[1, 2, 3]"), string("true"), string("[ true, false ]") }) {
     cout << "Parsing " << json.data() << " ..." << endl;
     auto [doc, error] = parser.parse(json);
     if (error) { cerr << "Error: " << error << endl; exit(1); }
-    if (!doc.print_json(cout)) { cerr << "print failed!\n"; exit(1); }
-    cout << endl;
+    cout << doc << endl;
+  }
+}
+
+void parser_parse_exception() {
+  cout << __func__ << endl;
+
+  // Allocate a parser big enough for all files
+  document::parser parser;
+
+  // Read files with the parser, one by one
+  for (padded_string json : { string("[1, 2, 3]"), string("true"), string("[ true, false ]") }) {
+    cout << "Parsing " << json.data() << " ..." << endl;
+    cout << parser.parse(json) << endl;
   }
 }
 
@@ -75,8 +76,7 @@ void parser_parse_many_error_code() {
   document::parser parser;
   for (auto [doc, error] : parser.parse_many(json)) {
     if (error) { cerr << "Error: " << error << endl; exit(1); }
-    if (!doc.print_json(cout)) { exit(1); }
-    cout << endl;
+    cout << doc << endl;
   }
 }
 
@@ -88,8 +88,7 @@ void parser_parse_many_exception() {
   cout << "Parsing " << json.data() << " ..." << endl;
   document::parser parser;
   for (const document &doc : parser.parse_many(json)) {
-    if (!doc.print_json(cout)) { exit(1); }
-    cout << endl;
+    cout << doc << endl;
   }
 }
 
@@ -101,7 +100,7 @@ void parser_parse_max_capacity() {
     auto [doc, error] = parser.parse(argv[i]);
     if (error == CAPACITY) { cerr << "JSON files larger than 1MB are not supported!" << endl; exit(1); }
     if (error) { cerr << error << endl; exit(1); }
-    doc.print_json(cout);
+    cout << doc << endl;
   }
 }
 
@@ -115,7 +114,7 @@ void parser_parse_fixed_capacity() {
     auto [doc, error] = parser.parse(argv[i]);
     if (error == CAPACITY) { cerr << "JSON files larger than 1MB are not supported!" << endl; exit(1); }
     if (error) { cerr << error << endl; exit(1); }
-    doc.print_json(cout);
+    cout << doc << endl;
   }
 }
 
@@ -126,7 +125,8 @@ int main() {
   document_parse_padded_string();
   document_parse_get_corpus();
   document_load();
-  parser_parse();
+  parser_parse_error_code();
+  parser_parse_exception();
   parser_parse_many_error_code();
   parser_parse_many_exception();
   parser_parse_max_capacity();


### PR DESCRIPTION
This patch supports `cout << doc` as well as any element, object or array in the document:

```c++
const document &doc = parser.parse(json);
cout << doc;
document::element foo = doc["foo"];
cout << foo;
```

Further, in keeping with other APIs, we support << against the results of operations that may fail. In case of failure, `<<` will rethrow the exception. It allows super clean syntax when combined with the other patches:

```c++
cout << parser.parse(json);
cout << parser.parse(json)["foo"];
```

I added tests for this, as well.

Fixes #528.