### PR TITLE
Support document::parse("[1,2,3]"_padded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,23 +142,23 @@ All examples below use use `#include "simdjson.h"`, `#include "simdjson.cpp"` an
 The simplest API to get started is `document::parse()`, which allocates a new parser, parses a string, and returns the DOM. This is less efficient if you're going to read multiple documents, but as long as you're only parsing a single document, this will do just fine.
 
 ```c++
-auto [doc, error] = document::parse(string("[ 1, 2, 3 ]"));
-if (error) { cerr << "Error: " << error_message(error) << endl; exit(1); }
+auto [doc, error] = document::parse("[ 1, 2, 3 ]"_padded);
+if (error) { cerr << "Error: " << error << endl; exit(1); }
 cout << doc;
 ```
 
 If you're using exceptions, it gets even simpler (simdjson won't use exceptions internally, so you'll only pay the performance cost of exceptions in your own calling code):
 
 ```c++
-document doc = document::parse(string("[ 1, 2, 3 ]"));
-cout << doc;
+cout << document::parse("[ 1, 2, 3 ]"_padded);
 ```
 
-The simdjson library requires SIMDJSON_PADDING extra bytes at the end of a string (it doesn't matter if the bytes are initialized). The `padded_string` class is an easy way to ensure this is accomplished up front and prevent the extra allocation:
+If you're wondering why the examples above use `_padded`, it's because the simdjson library requires SIMDJSON_PADDING extra bytes at the end of a string (it doesn't matter if the bytes are initialized). `_padded`
+is a way of creating a `padded_string` class, which assures us we have enough allocation.
 
 ```c++
-document doc = document::parse(padded_string(string("[ 1, 2, 3 ]")));
-cout << doc;
+padded_string json = "[ 1, 2, 3 ]"_padded;
+cout << document::parse(json);
 ```
 
 You can also load from a file with `parser.load()`:

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -1603,7 +1603,7 @@ private:
 /**
  * Minifies a JSON element or document, printing the smallest possible valid JSON.
  *
- *   document doc = document::parse("   [ 1 , 2 , 3 ] "_pad);
+ *   document doc = document::parse("   [ 1 , 2 , 3 ] "_padded);
  *   cout << minify(doc) << endl; // prints [1,2,3]
  *
  */

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -105,6 +105,10 @@ private:
 
 }; // padded_string
 
+inline padded_string operator "" _padded(const char *str, size_t len) {
+  return padded_string(str, len);
+}
+
 } // namespace simdjson
 
 namespace simdjson::internal {

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -6,8 +6,7 @@ using namespace simdjson;
 void document_parse_error_code() {
   cout << __func__ << endl;
 
-  string json("[ 1, 2, 3 ]");
-  auto [doc, error] = document::parse(json);
+  auto [doc, error] = document::parse("[ 1, 2, 3 ]"_padded);
   if (error) { cerr << "Error: " << error << endl; exit(1); }
   cout << doc << endl;
 }
@@ -15,14 +14,13 @@ void document_parse_error_code() {
 void document_parse_exception() {
   cout << __func__ << endl;
 
-  string json("[ 1, 2, 3 ]");
-  cout << document::parse(json) << endl;
+  cout << document::parse("[ 1, 2, 3 ]"_padded) << endl;
 }
 
 void document_parse_padded_string() {
   cout << __func__ << endl;
 
-  padded_string json(string("[ 1, 2, 3 ]"));
+  auto json = "[ 1, 2, 3 ]"_padded;
   cout << document::parse(json) << endl;
 }
 
@@ -71,7 +69,7 @@ void parser_parse_many_error_code() {
   cout << __func__ << endl;
 
   // Read files with the parser
-  padded_string json = string("[1, 2, 3] true [ true, false ]");
+  auto json = "[1, 2, 3] true [ true, false ]"_padded;
   cout << "Parsing " << json.data() << " ..." << endl;
   document::parser parser;
   for (auto [doc, error] : parser.parse_many(json)) {
@@ -84,7 +82,7 @@ void parser_parse_many_exception() {
   cout << __func__ << endl;
 
   // Read files with the parser
-  padded_string json = string("[1, 2, 3] true [ true, false ]");
+  auto json = "[1, 2, 3] true [ true, false ]"_padded;
   cout << "Parsing " << json.data() << " ..." << endl;
   document::parser parser;
   for (const document &doc : parser.parse_many(json)) {


### PR DESCRIPTION
This makes one-line examples with embedded text much easier to read, and also encourages the initialization of padded strings. Can be used like this:

```c++
cout << document::parse("[1,2,3]"_padded);
```

Or this:

```c++
auto json = "[1,2,3]"_padded; // Creates a `padded_string` type
cout << document::parse(json);
```

Fixes #527.