### PR TITLE
Fix parse benchmarker

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -298,7 +298,7 @@ struct benchmarker {
     // Allocate document::parser
     collector.start();
     document::parser parser;
-    error_code error = parser.set_capacity(json.size());
+    bool alloc_ok = parser.allocate_capacity(json.size());
     event_count allocate_count = collector.end();
     allocate_stage << allocate_count;
     // Run it once to get hot buffers
@@ -309,14 +309,14 @@ struct benchmarker {
       }
     }
 
-    if (error) {
+    if (!alloc_ok) {
       exit_error(string("Unable to allocate_stage ") + to_string(json.size()) + " bytes for the JSON result.");
     }
     verbose() << "[verbose] allocated memory for parsed JSON " << endl;
 
     // Stage 1 (find structurals)
     collector.start();
-    error = active_implementation->stage1((const uint8_t *)json.data(), json.size(), parser, false);
+    error_code error = active_implementation->stage1((const uint8_t *)json.data(), json.size(), parser, false);
     event_count stage1_count = collector.end();
     stage1 << stage1_count;
     if (error) {


### PR DESCRIPTION
The recent allocation patch changed how `parse` calls allocation, and did it wrongly. (Since it's calling stage1/stage2 internally, automatic allocation won't happen for the benchmarker.) Right now, it crashes every time you run it.

I have no IDEA how this could get in. I have not checked any of these patches in until all the tests show green, and I *know* we run the performance checker. I'll look into it, maybe there's a false positive when it crashes or something.