### PR TITLE
Split structural iteration from stage 2 parser (5% overall)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif # ifeq ($(SANITIZE),1)
 endif # ifeq ($(MEMSANITIZE),1)
 
 # Headers and sources
-SRCHEADERS_GENERIC=src/generic/numberparsing.h src/generic/stage1_find_marks.h src/generic/stage2_build_tape.h src/generic/stringparsing.h src/generic/stage2_streaming_build_tape.h src/generic/utf8_fastvalidate_algorithm.h src/generic/utf8_lookup_algorithm.h src/generic/utf8_lookup2_algorithm.h src/generic/utf8_range_algorithm.h src/generic/utf8_zwegner_algorithm.h
+SRCHEADERS_GENERIC=src/generic/atomparsing.h src/generic/numberparsing.h src/generic/stage1_find_marks.h src/generic/stage2_build_tape.h src/generic/stringparsing.h src/generic/stage2_streaming_build_tape.h src/generic/utf8_fastvalidate_algorithm.h src/generic/utf8_lookup_algorithm.h src/generic/utf8_lookup2_algorithm.h src/generic/utf8_range_algorithm.h src/generic/utf8_zwegner_algorithm.h
 SRCHEADERS_ARM64=      src/arm64/bitmanipulation.h    src/arm64/bitmask.h    src/arm64/intrinsics.h    src/arm64/numberparsing.h    src/arm64/simd.h    src/arm64/stage1_find_marks.h    src/arm64/stage2_build_tape.h    src/arm64/stringparsing.h
 SRCHEADERS_HASWELL=  src/haswell/bitmanipulation.h  src/haswell/bitmask.h  src/haswell/intrinsics.h  src/haswell/numberparsing.h  src/haswell/simd.h  src/haswell/stage1_find_marks.h  src/haswell/stage2_build_tape.h  src/haswell/stringparsing.h
 SRCHEADERS_WESTMERE=src/westmere/bitmanipulation.h src/westmere/bitmask.h src/westmere/intrinsics.h src/westmere/numberparsing.h src/westmere/simd.h src/westmere/stage1_find_marks.h src/westmere/stage2_build_tape.h src/westmere/stringparsing.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,43 +33,45 @@ set(SIMDJSON_SRC_HEADERS
   simdprune_tables.h
   stage1_find_marks.cpp
   stage2_build_tape.cpp
-  arm64/bitmask.h
-  arm64/simd.h
   arm64/bitmanipulation.h
+  arm64/bitmask.h
   arm64/implementation.h
   arm64/intrinsics.h
+  arm64/numberparsing.h
+  arm64/simd.h
   arm64/stage1_find_marks.h
   arm64/stage2_build_tape.h
   arm64/stringparsing.h
-  arm64/numberparsing.h
+  generic/atomparsing.h
+  generic/numberparsing.h
   generic/stage1_find_marks.h
   generic/stage2_build_tape.h
   generic/stage2_streaming_build_tape.h
   generic/stringparsing.h
-  generic/numberparsing.h
   generic/utf8_fastvalidate_algorithm.h
   generic/utf8_lookup_algorithm.h
   generic/utf8_lookup2_algorithm.h
   generic/utf8_range_algorithm.h
   generic/utf8_zwegner_algorithm.h
-  haswell/bitmask.h
   haswell/bitmanipulation.h
+  haswell/bitmask.h
   haswell/implementation.h
   haswell/intrinsics.h
+  haswell/numberparsing.h
   haswell/simd.h
   haswell/stage1_find_marks.h
   haswell/stage2_build_tape.h
   haswell/stringparsing.h
   document_parser_callbacks.h
   westmere/bitmanipulation.h
+  westmere/bitmask.h
   westmere/implementation.h
   westmere/intrinsics.h
-  westmere/bitmask.h
+  westmere/numberparsing.h
   westmere/simd.h
   westmere/stage1_find_marks.h
   westmere/stage2_build_tape.h
   westmere/stringparsing.h
-  westmere/numberparsing.h
 )
 set_source_files_properties(${SIMDJSON_SRC_HEADERS} PROPERTIES HEADER_FILE_ONLY TRUE)
 

--- a/src/arm64/stage2_build_tape.h
+++ b/src/arm64/stage2_build_tape.h
@@ -11,6 +11,7 @@
 
 namespace simdjson::arm64 {
 
+#include "generic/atomparsing.h"
 #include "generic/stage2_build_tape.h"
 #include "generic/stage2_streaming_build_tape.h"
 

--- a/src/generic/atomparsing.h
+++ b/src/generic/atomparsing.h
@@ -1,0 +1,49 @@
+namespace atomparsing {
+
+really_inline uint32_t string_to_uint32(const char* str) { return *reinterpret_cast<const uint32_t *>(str); }
+
+WARN_UNUSED
+really_inline bool str4ncmp(const uint8_t *src, const char* atom) {
+  uint32_t srcval; // we want to avoid unaligned 64-bit loads (undefined in C/C++)
+  static_assert(sizeof(uint32_t) <= SIMDJSON_PADDING);
+  std::memcpy(&srcval, src, sizeof(uint32_t));
+  return srcval ^ string_to_uint32(atom);
+}
+
+WARN_UNUSED
+really_inline bool is_valid_true_atom(const uint8_t *src) {
+  return (str4ncmp(src, "true") | is_not_structural_or_whitespace(src[4])) == 0;
+}
+
+WARN_UNUSED
+really_inline bool is_valid_true_atom(const uint8_t *src, size_t len) {
+  if (len > 4) { return is_valid_true_atom(src); }
+  else if (len == 4) { return !str4ncmp(src, "true"); }
+  else { return false; }
+}
+
+WARN_UNUSED
+really_inline bool is_valid_false_atom(const uint8_t *src) {
+  return (str4ncmp(src+1, "alse") | is_not_structural_or_whitespace(src[5])) == 0;
+}
+
+WARN_UNUSED
+really_inline bool is_valid_false_atom(const uint8_t *src, size_t len) {
+  if (len > 5) { return is_valid_false_atom(src); }
+  else if (len == 5) { return !str4ncmp(src+1, "alse"); }
+  else { return false; }
+}
+
+WARN_UNUSED
+really_inline bool is_valid_null_atom(const uint8_t *src) {
+  return (str4ncmp(src, "null") | is_not_structural_or_whitespace(src[4])) == 0;
+}
+
+WARN_UNUSED
+really_inline bool is_valid_null_atom(const uint8_t *src, size_t len) {
+  if (len > 4) { return is_valid_null_atom(src); }
+  else if (len == 4) { return !str4ncmp(src, "null"); }
+  else { return false; }
+}
+
+} // namespace atomparsing

--- a/src/generic/stage2_streaming_build_tape.h
+++ b/src/generic/stage2_streaming_build_tape.h
@@ -58,11 +58,7 @@ WARN_UNUSED error_code implementation::stage2(const uint8_t *buf, size_t len, do
     FAIL_IF( parser.parse_string() );
     goto finish;
   case 't': case 'f': case 'n':
-    FAIL_IF(
-      parser.structurals.with_space_terminated_copy([&](auto copy, auto idx) {
-        return parser.parse_atom(&copy[idx]);
-      })
-    );
+    FAIL_IF( parser.parse_single_atom() );
     goto finish;
   case '0': case '1': case '2': case '3': case '4':
   case '5': case '6': case '7': case '8': case '9':

--- a/src/generic/stringparsing.h
+++ b/src/generic/stringparsing.h
@@ -71,10 +71,9 @@ really_inline bool handle_unicode_codepoint(const uint8_t **src_ptr,
   return offset > 0;
 }
 
-WARN_UNUSED really_inline uint8_t *parse_string(const uint8_t *buf,
-                                                uint32_t offset,
+WARN_UNUSED really_inline uint8_t *parse_string(const uint8_t *src,
                                                 uint8_t *dst) {
-  const uint8_t *src = &buf[offset + 1]; /* we know that buf at offset is a " */
+  src++;
   while (1) {
     parse_string_helper helper = find_bs_bits_and_quote_bits(src, dst);
     if (((helper.bs_bits - 1) & helper.quote_bits) != 0) {

--- a/src/haswell/stage2_build_tape.h
+++ b/src/haswell/stage2_build_tape.h
@@ -12,6 +12,7 @@
 TARGET_HASWELL
 namespace simdjson::haswell {
 
+#include "generic/atomparsing.h"
 #include "generic/stage2_build_tape.h"
 #include "generic/stage2_streaming_build_tape.h"
 

--- a/src/stage2_build_tape.cpp
+++ b/src/stage2_build_tape.cpp
@@ -6,52 +6,6 @@
 
 using namespace simdjson;
 
-WARN_UNUSED
-really_inline bool is_valid_true_atom(const uint8_t *loc) {
-  uint32_t tv = *reinterpret_cast<const uint32_t *>("true");
-  uint32_t error = 0;
-  uint32_t
-      locval; // we want to avoid unaligned 64-bit loads (undefined in C/C++)
-  // this can read up to 3 bytes beyond the buffer size, but we require
-  // SIMDJSON_PADDING of padding
-  static_assert(sizeof(uint32_t) <= SIMDJSON_PADDING);
-  std::memcpy(&locval, loc, sizeof(uint32_t));
-  error = locval ^ tv;
-  error |= is_not_structural_or_whitespace(loc[4]);
-  return error == 0;
-}
-
-WARN_UNUSED
-really_inline bool is_valid_false_atom(const uint8_t *loc) {
-  // assume that loc starts with "f"
-  uint32_t fv = *reinterpret_cast<const uint32_t *>("alse");
-  uint32_t error = 0;
-  uint32_t
-      locval; // we want to avoid unaligned 32-bit loads (undefined in C/C++)
-  // this can read up to 4 bytes beyond the buffer size, but we require
-  // SIMDJSON_PADDING of padding
-  static_assert(sizeof(uint32_t) <= SIMDJSON_PADDING);
-  std::memcpy(&locval, loc + 1, sizeof(uint32_t));
-  error = locval ^ fv;
-  error |= is_not_structural_or_whitespace(loc[5]);
-  return error == 0;
-}
-
-WARN_UNUSED
-really_inline bool is_valid_null_atom(const uint8_t *loc) {
-  uint32_t nv = *reinterpret_cast<const uint32_t *>("null");
-  uint32_t error = 0;
-  uint32_t
-      locval; // we want to avoid unaligned 32-bit loads (undefined in C/C++)
-  // this can read up to 2 bytes beyond the buffer size, but we require
-  // SIMDJSON_PADDING of padding
-  static_assert(sizeof(uint32_t) - 1 <= SIMDJSON_PADDING);
-  std::memcpy(&locval, loc, sizeof(uint32_t));
-  error = locval ^ nv;
-  error |= is_not_structural_or_whitespace(loc[4]);
-  return error == 0;
-}
-
 #ifdef JSON_TEST_STRINGS
 void found_string(const uint8_t *buf, const uint8_t *parsed_begin,
                   const uint8_t *parsed_end);

--- a/src/westmere/stage2_build_tape.h
+++ b/src/westmere/stage2_build_tape.h
@@ -12,6 +12,7 @@
 TARGET_WESTMERE
 namespace simdjson::westmere {
 
+#include "generic/atomparsing.h"
 #include "generic/stage2_build_tape.h"
 #include "generic/stage2_streaming_build_tape.h"
 


### PR DESCRIPTION
In a first move towards a "stage 1 sax" for minification/pretty printing, I made a structural_iterator interface that takes care of advance_char() over structurals, and separated that from stage 2.

It buys us 5% overall (and 10% in stage 2), on Kady Lake R. That wasn't my intent at all :)

I'm guessing that, by peeling off `structural_indexes` into a specific member, the compiler now feels justified in enregistering it, and it's used often enough to make a difference.

### With patch

```
jkeiser@JKEISER-THINKPAD:~/simdjson$ make parse && ./parse jsonexamples/twitter.json -n 20000
g++ -msse4.2 -mpclmul  -std=c++17  -pthread -Wall -Wextra -Wshadow -Ibenchmark/linux -O3 -Isrc -Iinclude  -o parse benchmark/parse.cpp src/simdjson.cpp 
perf_event_open: Invalid argument
number of iterations 20000 
                                                     
jsonexamples/twitter.json
=========================
     9867 blocks -     631515 bytes - 55263 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages
|    Speed        :  23.3989 ns per block ( 96.86%) -   0.3656 ns per byte -   4.1782 ns per structural -    2.735 GB/s
|- Stage 1
|    Speed        :  11.0762 ns per block ( 45.85%) -   0.1731 ns per byte -   1.9778 ns per structural -    5.778 GB/s
|- Stage 2
|    Speed        :  12.1707 ns per block ( 50.38%) -   0.1902 ns per byte -   2.1732 ns per structural -    5.258 GB/s
```

### Without patch

```
jkeiser@JKEISER-THINKPAD:~/simdjson$ make parse && ./parse jsonexamples/twitter.json -n 20000
make: 'parse' is up to date.
perf_event_open: Invalid argument
number of iterations 20000 
                                                     
jsonexamples/twitter.json
=========================
     9867 blocks -     631515 bytes - 55263 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages
|    Speed        :  24.5744 ns per block ( 97.59%) -   0.3840 ns per byte -   4.3881 ns per structural -    2.604 GB/s
|- Stage 1
|    Speed        :  11.1573 ns per block ( 44.31%) -   0.1743 ns per byte -   1.9923 ns per structural -    5.736 GB/s
|- Stage 2
|    Speed        :  13.2651 ns per block ( 52.68%) -   0.2073 ns per byte -   2.3687 ns per structural -    4.824 GB/s
```
